### PR TITLE
Focus issues

### DIFF
--- a/src/components/ReaderSettings.tsx
+++ b/src/components/ReaderSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React from "react";
 
 import Locale from "../resources/locales/en.json";
 
@@ -6,26 +6,17 @@ import TextAreaIcon from "./assets/icons/textarea-icon.svg";
 import CloseIcon from "./assets/icons/close-icon.svg";
 import settingsStyles from "./assets/styles/readerSettings.module.css";
 
-import { Button, Dialog, DialogTrigger, Popover, PressEvent } from "react-aria-components"; 
+import { Button, Dialog, DialogTrigger, Popover } from "react-aria-components"; 
 import { ReadingDisplayCol } from "./ReadingDisplayCol";
 import { ReadingDisplayLayout } from "./ReadingDisplayLayout";
 
-import { setHovering, setImmersive, setSettingsOpen } from "@/lib/readerReducer";
+import { setHovering, setSettingsOpen } from "@/lib/readerReducer";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 
 export const ReaderSettings = () => {
-  const triggerButton = useRef<HTMLButtonElement | null>(null);
-  const [isDismissed, setDismissed] = useState(false);
   const isOpen = useAppSelector(state => state.reader.settingsOpen);
-  const isImmersive = useAppSelector(state => state.reader.isImmersive);
   const isFXL = useAppSelector(state => state.publication.isFXL);
   const dispatch = useAppDispatch();
-
-  // TMP: Vanilla React ARIA popover/modal components don’t provide a prop
-  // to prevent restoring of focus onto trigger on dismissal
-  // so we have to build custom components using hooks and focus utilities…
-  // We need to for actions and sheets anyway so no biggie, but in the meantime,
-  // we have to do this funky logic so that the behaviour can be tested and refined.
 
   const setOpen = (value: boolean) => {
     dispatch(setSettingsOpen(value));
@@ -34,49 +25,13 @@ export const ReaderSettings = () => {
     if (!value) dispatch(setHovering(false));
   }
 
-  // Intercepting CloseOnInteractOutside only to set various states…
-  const proxyCloseOnInteractOutside = () => {
-    // setting dismissed so that we can blur the trigger on focus…
-    setDismissed(true);
-    // setting immersive so that it doesn’t require 2 clicks…
-    dispatch(setImmersive(true));
-    // hover false otherwise it may not update as expected
-    dispatch(setHovering(false));
-    // Allow press on ARIA underlay to trigger close
-    return true;
-  }
-
-  const handleCloseButton = (event: PressEvent) => {
-    // If the event is anything else than keyboard, set dismissed
-    // The assumption is that you want to restore focus for keyboard nav
-    if (event.pointerType !== "keyboard") {
-      setDismissed(true);
-    }
-    // close the popover
-    setOpen(false);
-  }
-
-  // Check the trigger Button is dismissed and is in immersive mode to blur it
-  // when the focus is restored from the popover overlay
-  // We need to know whether it’s dismissed so that we don’t accidentally blur it
-  // and it becomes unavailable through keyboard nav…
-  const handleFocus = () => {
-    if (isDismissed && isImmersive && triggerButton.current) {
-      // reset dismissed so that trigger can become focusable again
-      setDismissed(false);
-      triggerButton.current.blur();
-    }
-  }
-
   return(
     <>
     <DialogTrigger>
       <Button 
-        ref={ triggerButton }
         className={ settingsStyles.textAreaButton } 
         aria-label={ Locale.reader.settings.trigger }
-        onPress={ () => setOpen(true) }
-        onFocus={ handleFocus }       
+        onPress={ () => setOpen(true) }     
       >
         <TextAreaIcon aria-hidden="true" focusable="false" />
       </Button>
@@ -85,13 +40,12 @@ export const ReaderSettings = () => {
         className={ settingsStyles.readerSettingsPopover }
         isOpen={ isOpen }
         onOpenChange={ setOpen } 
-        shouldCloseOnInteractOutside={ proxyCloseOnInteractOutside }
         >
         <Dialog>
           <Button 
             className={ settingsStyles.closeButton } 
             aria-label={ Locale.reader.settings.close } 
-            onPress={ handleCloseButton }
+            onPress={ () => setOpen(false) }
           >
             <CloseIcon aria-hidden="true" focusable="false" />
           </Button>

--- a/src/components/assets/styles/arrowButton.module.css
+++ b/src/components/assets/styles/arrowButton.module.css
@@ -37,6 +37,7 @@
   border: none;
   color: inherit;
   font: inherit;
+  outline: none;
 
   width: var(--arrow-size, 40px);
   /* height: var(--arrow-size, 40px); */
@@ -60,7 +61,8 @@
   pointer-events: none;
 }
 
-.container button:focus {
+.container button[data-focused] {
+  outline: auto;
   opacity: 1;
 }
 

--- a/src/components/assets/styles/readerSettings.module.css
+++ b/src/components/assets/styles/readerSettings.module.css
@@ -35,6 +35,11 @@
   width: var(--icon-size, 32px);
   height: var(--icon-size, 32px);
   text-align: center;
+  outline: none;
+}
+
+.textAreaButton[data-focus-visible] {
+  outline: auto;
 }
 
 .closeButton {


### PR DESCRIPTION
Re #29 but partially addresses it, more has to be done on Actions branch given the extent of the Setting component refactoring.

This should already help with most issues, inspired from the React Aria Components’ own styles so that should be OK, a11y-wise. 

- Switched to React Aria data-attributes to style focus instead of vanilla-CSS pseudo-classes, especially as `focus` seems to be handled programmatically.
- Disables focus on non-keyboard interactions
- When focus is not visible, immersive mode should behave normally.

That was tested on a large amount of actual devices using BrowserStack but of course that doesn’t mean you may encounter issues. 

Known edge cases:
- When focus is visible e.g. using the `Escape` Key or clicking the close button using `Enter/Space` Keys, the focus ring will be visible in immersive mode. First click will dismiss it, second will toggle immersive. It’s not necessarily a rare occurrence as one might use a mouse to click actions and menus, and `Escape` to close them – some sort of hybrid use. 

There’s no simple/trivial solution to this given how complex focus management becomes at this point, with multiple factors to take into account, so it will be preferable to address this in Actions – with this PR merged into it. 