### PR TITLE
proof of concept for a module-scoped navigator instance

### DIFF
--- a/src/components/TocAction.tsx
+++ b/src/components/TocAction.tsx
@@ -9,12 +9,13 @@ import tocStyles from "./assets/styles/toc.module.css";
 import TocIcon from "./assets/icons/toc.svg";
 import CloseIcon from "./assets/icons/close.svg";
 
-import { Links } from "@readium/shared";
+import { Link, Links } from "@readium/shared";
 
 import { ActionIcon } from "./Templates/ActionIcon";
-import { Button, Dialog, DialogTrigger, Heading, ListBox, ListBoxItem, Popover } from "react-aria-components";
+import { Button, Dialog, DialogTrigger, Heading, ListBox, ListBoxItem, Popover, Selection } from "react-aria-components";
 
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
+import { useEpubNavigator } from "@/hooks/useEpubNavigator";
 import { setTocOpen } from "@/lib/readerReducer";
 import { OverflowMenuItem } from "./Templates/OverflowMenuItem";
 import { ActionComponentVariant, ActionKeys, IActionComponent } from "./Templates/ActionComponent";
@@ -22,10 +23,16 @@ import { ActionComponentVariant, ActionKeys, IActionComponent } from "./Template
 export const TocAction: React.FC<IActionComponent & { toc: Links }> = ({ variant, toc }) => {
   const isOpen = useAppSelector(state => state.reader.tocOpen);
   const dispatch = useAppDispatch();
+  const { goLink } = useEpubNavigator();
 
   const setOpen = (value: boolean) => {
     dispatch(setTocOpen(value));
   }
+
+  const handleClick = (href:string) => {
+    const link:Link = new Link({href:href});
+    goLink(link,true, () => {});
+  };
 
   if (variant && variant === ActionComponentVariant.menu) {
     return(
@@ -69,7 +76,7 @@ export const TocAction: React.FC<IActionComponent & { toc: Links }> = ({ variant
             <Heading slot="title" className={ readerSharedUI.popoverHeading }>{ Locale.reader.toc.heading }</Heading>
             { toc.items.length > 0 
               ? <ListBox className={ tocStyles.listBox } items={ toc.items }>
-                  { item => <ListBoxItem className={ tocStyles.listItem } id={ item.title } data-href={ item.href }>{ item.title }</ListBoxItem> }
+                  { item => <ListBoxItem className={ tocStyles.listItem } id={ item.title } data-href={ item.href }><div style={{ cursor: "pointer" }} onClick={() => handleClick(item.href)}>{item.title}</div></ListBoxItem> }
                 </ListBox>
               : <div className={ tocStyles.empty }>{ Locale.reader.toc.empty }</div>
             }

--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -179,7 +179,7 @@ export const RSPrefs = {
     displayOrder: [
       ActionKeys.settings,
       ActionKeys.fullscreen,
-    //  ActionKeys.toc,
+      ActionKeys.toc,
     //  ActionKeys.jumpToPosition
     ],
     [ActionKeys.settings]: {


### PR DESCRIPTION
In useEpubNavigator the EpubNavigator object is stored in local scope which means that each component using the hook would see a new instance of this object and could not 'share navigation' with one Navigator:
`const nav = useRef<EpubNavigator | null>(null);`

There are many ways to potentially lift the scope of this value so that every component could use the same navigator (including using redux, etc.) but it seems like simply lifting the navigator object from local to module scope is exactly what we need.  This is done by declaring the var for the EpubNavigator object outside of the hook definition.  When a hook is imported into a file, its top-level variables are shared across all files importing the module and JavaScript ensures that the module is loaded only once, thereby creating a singleton pattern for the navigator object. EpubNavigatorLoad is still allowed to create new instances of the object which would not cause a component re-render.

This pull request shows an example of this idea, using the existing TOC Listbox to show a shared Navigator by importing goLink from EpubNavigator to jump to toc locations, to spark discussions.  