### PR TITLE
iPadOSPatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-stately": "^3.36.1"
   },
   "devDependencies": {
-    "@readium/css": "github:readium/readium-css",
+    "@readium/css": ">=2.0.0-beta.11",
     "@svgr/webpack": "^8.1.0",
     "@types/json-templates": "^3.0.3",
     "@types/node": "^22.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,8 +61,8 @@ importers:
         version: 3.36.1(react@19.1.0)
     devDependencies:
       '@readium/css':
-        specifier: github:readium/readium-css
-        version: https://codeload.github.com/readium/readium-css/tar.gz/bbda8f6f1d0b81c11401b62db8118a04e046ffad
+        specifier: '>=2.0.0-beta.11'
+        version: 2.0.0-beta.11
       '@svgr/webpack':
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.8.2)
@@ -1601,9 +1601,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@readium/css@https://codeload.github.com/readium/readium-css/tar.gz/bbda8f6f1d0b81c11401b62db8118a04e046ffad':
-    resolution: {tarball: https://codeload.github.com/readium/readium-css/tar.gz/bbda8f6f1d0b81c11401b62db8118a04e046ffad}
-    version: 2.0.0-beta.7
+  '@readium/css@2.0.0-beta.11':
+    resolution: {integrity: sha512-mZw2rH43Z36lspXzuYCO7LUaIgewWjKDFEL4Vyf+/QAR9Sr2eR9H2RiSPq4YM5ldDs3vlTH87r+LW4CSgwfFxg==}
 
   '@reduxjs/toolkit@2.6.1':
     resolution: {integrity: sha512-SSlIqZNYhqm/oMkXbtofwZSt9lrncblzo6YcZ9zoX+zLngRBrCOjK4lNLdkNucJF58RHOWrD9txT3bT3piH7Zw==}
@@ -5382,7 +5381,7 @@ snapshots:
       '@react-types/shared': 3.28.0(react@19.1.0)
       react: 19.1.0
 
-  '@readium/css@https://codeload.github.com/readium/readium-css/tar.gz/bbda8f6f1d0b81c11401b62db8118a04e046ffad': {}
+  '@readium/css@2.0.0-beta.11': {}
 
   '@reduxjs/toolkit@2.6.1(react-redux@9.2.0(@types/react@19.1.0)(react@19.1.0)(redux@5.0.1))(react@19.1.0)':
     dependencies:

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -79,9 +79,10 @@ import {
   setTocTree, 
   setTocEntry
 } from "@/lib/publicationReducer";
+import { Dispatch } from "@reduxjs/toolkit";
 
 import debounce from "debounce";
-import { Dispatch } from "@reduxjs/toolkit";
+import { isIpadOS } from "@/helpers/keyboard/getPlatform";
 
 export const Reader = ({ rawManifest, selfHref }: { rawManifest: object, selfHref: string }) => {
   const container = useRef<HTMLDivElement>(null);
@@ -599,6 +600,7 @@ export const Reader = ({ rawManifest, selfHref }: { rawManifest: object, selfHre
         };
 
         const defaults: IEpubDefaults = isFXL ? {} : {
+          iPadOSPatch: isIpadOS(),
           layoutStrategy: RSPrefs.typography.layoutStrategy as LayoutStrategy | null | undefined,
           maximalLineLength: RSPrefs.typography.maximalLineLength, 
           minimalLineLength: RSPrefs.typography.minimalLineLength, 

--- a/src/components/Reader.tsx
+++ b/src/components/Reader.tsx
@@ -82,7 +82,6 @@ import {
 import { Dispatch } from "@reduxjs/toolkit";
 
 import debounce from "debounce";
-import { isIpadOS } from "@/helpers/keyboard/getPlatform";
 
 export const Reader = ({ rawManifest, selfHref }: { rawManifest: object, selfHref: string }) => {
   const container = useRef<HTMLDivElement>(null);
@@ -600,7 +599,6 @@ export const Reader = ({ rawManifest, selfHref }: { rawManifest: object, selfHre
         };
 
         const defaults: IEpubDefaults = isFXL ? {} : {
-          iPadOSPatch: isIpadOS(),
           layoutStrategy: RSPrefs.typography.layoutStrategy as LayoutStrategy | null | undefined,
           maximalLineLength: RSPrefs.typography.maximalLineLength, 
           minimalLineLength: RSPrefs.typography.minimalLineLength, 

--- a/src/helpers/keyboard/getPlatform.ts
+++ b/src/helpers/keyboard/getPlatform.ts
@@ -37,6 +37,13 @@ export const isMacish = () => {
   return MacOSPattern.test(platform);
 }
 
+// “Desktop-class” iPadOS
+export const isIpadOS = () => {
+  return !!(navigator.maxTouchPoints 
+        && navigator.maxTouchPoints > 2 
+        && navigator.userAgent.includes("Intel"));
+}
+
 // Stopgap measure for fullscreen on iPadOS, do not use elsewhere
 export const isIOSish = () => {
   const AppleMobilePattern = /ipod|iphone|ipad/i;
@@ -44,9 +51,6 @@ export const isIOSish = () => {
   if (AppleMobilePattern.test(platform)) {
     return true;
   } else {
-    // “Desktop-class” iPadOS
-    return navigator.maxTouchPoints 
-        && navigator.maxTouchPoints > 2 
-        && navigator.userAgent.includes("Mac");
+    return isIpadOS();
   }
 }


### PR DESCRIPTION
On iPadOS the desktop version of the website is requested by default, which should not be an issue. Except Apple is implementing some interventions on top of it for their “desktop-class” experience. One of these interventions disables `zoom`. 

There is a way around it, `-webkit-text-size-adjust: none`, but once again, it is an issue because it will break in various ways e.g. headings are not zoomed properly, nor are nodes with `font` styling such as small-caps, italic, bold, etc.

To get around this issue, we have to sanitise elements using `-webkit-text-zoom`. 