### PR TITLE
ability to choose the language for the interface (+ polish translation)

### DIFF
--- a/src/components/Actions/Fullscreen/StatefulFullscreenTrigger.tsx
+++ b/src/components/Actions/Fullscreen/StatefulFullscreenTrigger.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
 
 import { ThActionsKeys } from "@/preferences/models/enums";
 import { StatefulActionTriggerProps } from "../models/actions";
@@ -27,6 +27,7 @@ export const StatefulFullscreenTrigger = ({ variant }: StatefulActionTriggerProp
   // Note: Not using React Aria ToggleButton here as fullscreen is quite
   // difficult to control in isolation due to collapsibility + shortcuts
 
+  const locale = useLocale();
   const RSPrefs = usePreferences();
 
   const dispatch = useAppDispatch();
@@ -36,7 +37,7 @@ export const StatefulFullscreenTrigger = ({ variant }: StatefulActionTriggerProp
   
   const fs = useFullscreen(onChange);
 
-  const label = fs.isFullscreen ? Locale.reader.fullscreen.close : Locale.reader.fullscreen.trigger;
+  const label = fs.isFullscreen ? locale.reader.fullscreen.close : locale.reader.fullscreen.trigger;
   const Icon = fs.isFullscreen ? FullscreenExit : FullscreenCorners;
 
   const handlePress = () => {
@@ -67,7 +68,7 @@ export const StatefulFullscreenTrigger = ({ variant }: StatefulActionTriggerProp
           visibility={ RSPrefs.actions.keys[ThActionsKeys.fullscreen].visibility }  
           aria-label={ label }
           placement="bottom" 
-          tooltipLabel={ Locale.reader.fullscreen.tooltip } 
+          tooltipLabel={ locale.reader.fullscreen.tooltip } 
           onPress={ handlePress } 
         >
           <Icon aria-hidden="true" focusable="false" />

--- a/src/components/Actions/JumpToPosition/StatefulJumpToPositionContainer.tsx
+++ b/src/components/Actions/JumpToPosition/StatefulJumpToPositionContainer.tsx
@@ -2,7 +2,7 @@
 
 import React, { FormEvent, useCallback, useEffect, useState } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
 
 import { ThActionsKeys } from "@/preferences/models/enums";
 import { StatefulActionContainerProps } from "../models/actions";
@@ -24,6 +24,7 @@ import parseTemplate from "json-templates";
 export const StatefulJumpToPositionContainer = ({ 
   triggerRef 
 }: StatefulActionContainerProps) => {
+  const locale = useLocale();
   const actionState = useAppSelector(state => state.actions.keys[ThActionsKeys.jumpToPosition]);
   const positionsList = useAppSelector(state => state.publication.positionsList);
 
@@ -53,7 +54,7 @@ export const StatefulJumpToPositionContainer = ({
 
   // Label indicates the total number of positions for the book
   const makeFieldLabel = useCallback(() => {
-    const jsonTemplate = parseTemplate(Locale.reader.jumpToPosition.label);
+    const jsonTemplate = parseTemplate(locale.reader.jumpToPosition.label);
     return jsonTemplate({ positionStart: 1, positionEnd: positionsList.length });
   }, [positionsList]);
 
@@ -100,7 +101,7 @@ export const StatefulJumpToPositionContainer = ({
         sheetProps={{
           id: ThActionsKeys.jumpToPosition,
           triggerRef: triggerRef,
-          heading: Locale.reader.jumpToPosition.heading,
+          heading: locale.reader.jumpToPosition.heading,
           className: jumpToPositionStyles.jumpToPosition,
           placement: "bottom",
           isOpen: actionState?.isOpen || false,
@@ -110,7 +111,7 @@ export const StatefulJumpToPositionContainer = ({
         }}
       >
         <ThForm
-          label={ Locale.reader.jumpToPosition.go }
+          label={ locale.reader.jumpToPosition.go }
           className={ jumpToPositionStyles.jumpToPositionForm }
           onSubmit={ handleAction }
           compounds={{

--- a/src/components/Actions/JumpToPosition/StatefulJumpToPositionTrigger.tsx
+++ b/src/components/Actions/JumpToPosition/StatefulJumpToPositionTrigger.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
 
 import { ThActionsKeys } from "@/preferences/models/enums";
 import { StatefulActionTriggerProps } from "../models/actions";
@@ -18,6 +18,7 @@ import { usePreferences } from "@/preferences/hooks/usePreferences";
 import { setActionOpen, useAppDispatch, useAppSelector } from "@/lib";
 
 export const StatefulJumpToPositionTrigger = ({ variant }: StatefulActionTriggerProps) => {
+  const locale = useLocale();
   const RSPrefs = usePreferences();
   const actionState = useAppSelector(state => state.actions.keys[ThActionsKeys.jumpToPosition]);
   const positionsList = useAppSelector(state => state.publication.positionsList);
@@ -37,7 +38,7 @@ export const StatefulJumpToPositionTrigger = ({ variant }: StatefulActionTrigger
     <>
     { (variant && variant === ThActionsTriggerVariant.menu) 
      ? <StatefulOverflowMenuItem 
-         label={ Locale.reader.jumpToPosition.trigger }
+         label={ locale.reader.jumpToPosition.trigger }
           SVGIcon={ TargetIcon }
           shortcut={ RSPrefs.actions.keys[ThActionsKeys.jumpToPosition].shortcut }
           id={ ThActionsKeys.jumpToPosition }
@@ -45,9 +46,9 @@ export const StatefulJumpToPositionTrigger = ({ variant }: StatefulActionTrigger
         />
       : <StatefulActionIcon
           visibility={ RSPrefs.actions.keys[ThActionsKeys.jumpToPosition].visibility } 
-          aria-label={ Locale.reader.jumpToPosition.trigger }
+          aria-label={ locale.reader.jumpToPosition.trigger }
           placement="bottom" 
-          tooltipLabel={ Locale.reader.jumpToPosition.tooltip }
+          tooltipLabel={ locale.reader.jumpToPosition.tooltip }
           onPress={ () => setOpen(!actionState?.isOpen) }
         >
           <TargetIcon aria-hidden="true" focusable="false" />

--- a/src/components/Actions/Settings/StatefulSettingsContainer.tsx
+++ b/src/components/Actions/Settings/StatefulSettingsContainer.tsx
@@ -10,7 +10,7 @@ import {
   usePreferenceKeys
 } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
 
 import { 
   ThActionsKeys, 
@@ -51,6 +51,7 @@ export const StatefulSettingsContainer = ({
   const contains = useAppSelector(state => state.reader.settingsContainer);
   const actionState = useAppSelector(state => state.actions.keys[ThActionsKeys.settings]);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const settingItems = useMemo(() => {
     return isFXL ? fxlSettingsKeys : reflowSettingsKeys
@@ -124,14 +125,14 @@ export const StatefulSettingsContainer = ({
   const getHeading = useCallback(() => {
     switch (contains) {
       case ThSettingsContainerKeys.text:
-        return Locale.reader.settings.text.title;
+        return locale.reader.settings.text.title;
 
       case ThSettingsContainerKeys.spacing:
-        return Locale.reader.settings.spacing.title;
+        return locale.reader.settings.spacing.title;
 
       case ThSettingsContainerKeys.initial:
       default:
-        return Locale.reader.settings.heading;
+        return locale.reader.settings.heading;
     }
   }, [contains]);
 

--- a/src/components/Actions/Settings/StatefulSettingsTrigger.tsx
+++ b/src/components/Actions/Settings/StatefulSettingsTrigger.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
+
 
 import TuneIcon from "./assets/icons/match_case.svg";
 
@@ -21,6 +22,7 @@ export const StatefulSettingsTrigger = ({ variant }: StatefulActionTriggerProps)
   const RSPrefs = usePreferences();
   const actionState = useAppSelector(state => state.actions.keys[ThActionsKeys.settings]);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const setOpen = (value: boolean) => {    
     dispatch(setActionOpen({
@@ -36,7 +38,7 @@ export const StatefulSettingsTrigger = ({ variant }: StatefulActionTriggerProps)
     <>
     { (variant && variant === ThActionsTriggerVariant.menu) 
       ? <StatefulOverflowMenuItem 
-          label={ Locale.reader.settings.trigger }
+          label={ locale.reader.settings.trigger }
           SVGIcon={ TuneIcon }
           shortcut={ RSPrefs.actions.keys[ThActionsKeys.settings].shortcut } 
           id={ ThActionsKeys.settings }
@@ -44,9 +46,9 @@ export const StatefulSettingsTrigger = ({ variant }: StatefulActionTriggerProps)
         />
       : <StatefulActionIcon 
           visibility={ RSPrefs.actions.keys[ThActionsKeys.settings].visibility }
-          aria-label={ Locale.reader.settings.trigger }
+          aria-label={ locale.reader.settings.trigger }
           placement="bottom" 
-          tooltipLabel={ Locale.reader.settings.tooltip } 
+          tooltipLabel={ locale.reader.settings.tooltip }
           onPress={ () => setOpen(!actionState?.isOpen) }
         >
           <TuneIcon aria-hidden="true" focusable="false" />

--- a/src/components/Actions/StatefulOverflowMenu.tsx
+++ b/src/components/Actions/StatefulOverflowMenu.tsx
@@ -2,7 +2,7 @@
 
 import React, { ReactNode, RefObject } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import overflowMenuStyles from "./assets/styles/overflowMenu.module.css";
 
@@ -36,6 +36,7 @@ export const StatefulOverflowMenu = ({
   items,
   triggerRef
 }: StatefulOverflowMenuProps) => {
+  const locale = useLocale();
   const dispatch = useAppDispatch();
 
   const toggleMenuState = (value: boolean) => {
@@ -66,9 +67,9 @@ export const StatefulOverflowMenu = ({
           button: (
             <StatefulActionIcon
               className={ className ? className : overflowMenuStyles.activeButton }
-              aria-label={ Locale.reader.overflowMenu.active.trigger }
+              aria-label={ locale.reader.overflowMenu.active.trigger }
               placement="bottom"
-              tooltipLabel={ Locale.reader.overflowMenu.active.tooltip }
+              tooltipLabel={ locale.reader.overflowMenu.active.tooltip }
               visibility={ ThCollapsibilityVisibility.always }
             >
               <MenuIcon aria-hidden="true" focusable="false" />
@@ -84,9 +85,9 @@ export const StatefulOverflowMenu = ({
         <>
         <StatefulActionIcon 
           className={ className ? className : overflowMenuStyles.hintButton } 
-          aria-label={ Locale.reader.overflowMenu.hint.trigger }
+          aria-label={ locale.reader.overflowMenu.hint.trigger }
           placement="bottom"
-          tooltipLabel={ Locale.reader.overflowMenu.hint.tooltip } 
+          tooltipLabel={ locale.reader.overflowMenu.hint.tooltip } 
           visibility={ ThCollapsibilityVisibility.always }
           onPress={ () => { dispatch(toggleImmersive()) } }
           preventFocusOnPress={ true }

--- a/src/components/Actions/Toc/StatefulTocContainer.tsx
+++ b/src/components/Actions/Toc/StatefulTocContainer.tsx
@@ -2,7 +2,7 @@
 
 import React, { CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
 
 import { Link } from "@readium/shared";
 import { ThActionsKeys, ThDockingKeys, ThSheetTypes, ThLayoutDirection } from "@/preferences/models/enums";
@@ -34,6 +34,7 @@ import { setHovering, setImmersive } from "@/lib/readerReducer";
 import { isActiveElement } from "@/core/Helpers/focusUtilities";
 
 export const StatefulTocContainer = ({ triggerRef }: StatefulActionContainerProps) => {
+  const locale = useLocale();
   const treeRef = useRef<HTMLDivElement | null>(null);
   
   const tocEntry = useAppSelector(state => state.publication.tocEntry);
@@ -163,7 +164,7 @@ export const StatefulTocContainer = ({ triggerRef }: StatefulActionContainerProp
       sheetProps={ {
         id: ThActionsKeys.toc,
         triggerRef: triggerRef, 
-        heading: Locale.reader.toc.heading,
+        heading: locale.reader.toc.heading,
         className: tocStyles.toc,
         placement: "bottom",
         isOpen: actionState?.isOpen || false,
@@ -176,7 +177,7 @@ export const StatefulTocContainer = ({ triggerRef }: StatefulActionContainerProp
       { tocTree && tocTree.length > 0 
       ? (<>
         <ThFormSearchField
-          aria-label={ Locale.reader.toc.search.label }
+          aria-label={ locale.reader.toc.search.label }
           value={ filterValue }
           onChange={ setFilterValue }
           onClear={ () => setFilterValue("") }
@@ -188,7 +189,7 @@ export const StatefulTocContainer = ({ triggerRef }: StatefulActionContainerProp
             input: {
               ref: searchInputRef,
               className: tocStyles.tocSearchInput,
-              placeholder: Locale.reader.toc.search.placeholder
+              placeholder: locale.reader.toc.search.placeholder
             },
             searchIcon: {
               className: tocStyles.tocSearchIcon,
@@ -204,7 +205,7 @@ export const StatefulTocContainer = ({ triggerRef }: StatefulActionContainerProp
           // TODO: Remove this when we handle fragments
           key={ forceRerender }
           ref={ treeRef }
-          aria-label={ Locale.reader.toc.entries }
+          aria-label={ locale.reader.toc.entries }
           selectionMode="single"
           items={ displayedTocTree }
           className={ tocStyles.tocTree }
@@ -247,7 +248,7 @@ export const StatefulTocContainer = ({ triggerRef }: StatefulActionContainerProp
           } }
         </Tree>
       </>) 
-      : <div className={ tocStyles.empty }>{ Locale.reader.toc.empty }</div>
+      : <div className={ tocStyles.empty }>{ locale.reader.toc.empty }</div>
     }
     </StatefulSheetWrapper>
     </>

--- a/src/components/Actions/Toc/StatefulTocTrigger.tsx
+++ b/src/components/Actions/Toc/StatefulTocTrigger.tsx
@@ -2,7 +2,7 @@
 
 import { ThActionsKeys } from "@/preferences/models/enums";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../../Epub/AppLocale";
 
 import TocIcon from "./assets/icons/toc.svg";
 
@@ -18,6 +18,7 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { setActionOpen } from "@/lib/actionsReducer";
 
 export const StatefulTocTrigger = ({ variant }: StatefulActionTriggerProps) => {
+  const locale = useLocale();
   const RSPrefs = usePreferences();
   const actionState = useAppSelector(state => state.actions.keys[ThActionsKeys.toc]);
   const dispatch = useAppDispatch();
@@ -33,7 +34,7 @@ export const StatefulTocTrigger = ({ variant }: StatefulActionTriggerProps) => {
     <>
     { (variant && variant === ThActionsTriggerVariant.menu) 
       ? <StatefulOverflowMenuItem 
-          label={ Locale.reader.toc.trigger }
+          label={ locale.reader.toc.trigger }
           SVGIcon={ TocIcon } 
           shortcut={ RSPrefs.actions.keys[ThActionsKeys.toc].shortcut }
           id={ ThActionsKeys.toc }
@@ -41,9 +42,9 @@ export const StatefulTocTrigger = ({ variant }: StatefulActionTriggerProps) => {
         />
       : <StatefulActionIcon 
           visibility={ RSPrefs.actions.keys[ThActionsKeys.toc].visibility }
-          aria-label={ Locale.reader.toc.trigger } 
+          aria-label={ locale.reader.toc.trigger } 
           placement="bottom"
-          tooltipLabel={ Locale.reader.toc.tooltip } 
+          tooltipLabel={ locale.reader.toc.tooltip } 
           onPress={ () => setOpen(!actionState?.isOpen) }
         >
           <TocIcon aria-hidden="true" focusable="false" />

--- a/src/components/Docking/StatefulDockEnd.tsx
+++ b/src/components/Docking/StatefulDockEnd.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import readerSharedUI from "../assets/styles/readerSharedUI.module.css";
 
@@ -27,8 +27,9 @@ export const StatefulDockEnd = ({ variant, associatedKey }: StatefulActionTrigge
   const direction = useAppSelector(state => state.reader.direction);
   const actionsMap = useAppSelector(state => state.actions.keys);
   const isRTL = direction === ThLayoutDirection.rtl;
-  const localeKey = isRTL ? Locale.reader.app.docker.dockToLeft : Locale.reader.app.docker.dockToRight;
-
+  const locale = useLocale();
+  const localeKey = isRTL ? locale.reader.app.docker.dockToLeft : locale.reader.app.docker.dockToRight;
+  
   const actions = useActions(actionsMap);
   const isDisabled = actions.whichDocked(associatedKey) === ThDockingKeys.end;
 

--- a/src/components/Docking/StatefulDockStart.tsx
+++ b/src/components/Docking/StatefulDockStart.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import readerSharedUI from "../assets/styles/readerSharedUI.module.css";
 
@@ -27,7 +27,8 @@ export const StatefulDockStart = ({ variant, associatedKey }: StatefulActionTrig
   const direction = useAppSelector(state => state.reader.direction);
   const actionsMap = useAppSelector(state => state.actions.keys);
   const isRTL = direction === ThLayoutDirection.rtl;
-  const localeKey = isRTL ? Locale.reader.app.docker.dockToRight : Locale.reader.app.docker.dockToLeft;
+  const locale = useLocale();
+  const localeKey = isRTL ? locale.reader.app.docker.dockToRight : locale.reader.app.docker.dockToLeft;
 
   const actions = useActions(actionsMap);
   const isDisabled = actions.whichDocked(associatedKey) === ThDockingKeys.start;

--- a/src/components/Docking/StatefulDockTransientFullscreen.tsx
+++ b/src/components/Docking/StatefulDockTransientFullscreen.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import readerSharedUI from "../assets/styles/readerSharedUI.module.css";
 
@@ -28,6 +28,7 @@ export const StatefulDockTransientFullscreen = ({ variant, associatedKey }: Stat
   const isDisabled = !actions.isDocked(associatedKey) || actions.whichDocked(associatedKey) === ThDockingKeys.transient;
   
   const dispatch = useAppDispatch();
+  const locale = useLocale();
     
   const handlePress = useCallback(() => {
     if (associatedKey) {
@@ -42,7 +43,7 @@ export const StatefulDockTransientFullscreen = ({ variant, associatedKey }: Stat
     <>
     { (variant && variant === ThActionsTriggerVariant.menu) 
       ? <StatefulOverflowMenuItem 
-          label={ Locale.reader.app.docker.fullscreen.trigger }
+          label={ locale.reader.app.docker.fullscreen.trigger }
           SVGIcon={ Dialog } 
           shortcut={ RSPrefs.docking.keys[ThDockingKeys.transient].shortcut }
           onAction={ handlePress } 
@@ -51,9 +52,9 @@ export const StatefulDockTransientFullscreen = ({ variant, associatedKey }: Stat
         />
       : <StatefulActionIcon 
           className={ readerSharedUI.dockerButton }  
-          aria-label={ Locale.reader.app.docker.fullscreen.trigger }
+          aria-label={ locale.reader.app.docker.fullscreen.trigger }
           placement="bottom" 
-          tooltipLabel={ Locale.reader.app.docker.fullscreen.tooltip } 
+          tooltipLabel={ locale.reader.app.docker.fullscreen.tooltip } 
           onPress={ handlePress } 
           isDisabled={ isDisabled }
         >

--- a/src/components/Docking/StatefulDockTransientPopover.tsx
+++ b/src/components/Docking/StatefulDockTransientPopover.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import readerSharedUI from "../assets/styles/readerSharedUI.module.css";
 
@@ -28,6 +28,7 @@ export const StatefulDockTransientPopover = ({ variant, associatedKey }: Statefu
   const isDisabled = !actions.isDocked(associatedKey) || actions.whichDocked(associatedKey) === ThDockingKeys.transient;
     
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const handlePress = useCallback(() => {
     if (associatedKey) {
@@ -42,7 +43,7 @@ export const StatefulDockTransientPopover = ({ variant, associatedKey }: Statefu
     <>
     { (variant && variant === ThActionsTriggerVariant.menu) 
       ? <StatefulOverflowMenuItem 
-          label={ Locale.reader.app.docker.popover.trigger }
+          label={ locale.reader.app.docker.popover.trigger }
           SVGIcon={ Stack } 
           shortcut={ RSPrefs.docking.keys[ThDockingKeys.transient].shortcut }
           onAction={ handlePress } 
@@ -51,9 +52,9 @@ export const StatefulDockTransientPopover = ({ variant, associatedKey }: Statefu
         />
       : <StatefulActionIcon 
           className={ readerSharedUI.dockerButton }  
-          aria-label={ Locale.reader.app.docker.popover.trigger }
+          aria-label={ locale.reader.app.docker.popover.trigger }
           placement="bottom" 
-          tooltipLabel={ Locale.reader.app.docker.popover.tooltip } 
+          tooltipLabel={ locale.reader.app.docker.popover.tooltip } 
           onPress={ handlePress } 
           isDisabled={ isDisabled }
         >

--- a/src/components/Docking/StatefulDocker.tsx
+++ b/src/components/Docking/StatefulDocker.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import dockingStyles from "./assets/styles/docking.module.css";
 import readerSharedUI from "../assets/styles/readerSharedUI.module.css";
@@ -49,6 +49,7 @@ export const StatefulDocker = ({
   onClose
 }: StatefulDockerProps) => {
   const RSPrefs = usePreferences();
+  const locale = useLocale();
   
   const listActionItems = useCallback(() => {
     const actionsItems: ThActionEntry<ThDockingKeys>[] = [];
@@ -73,13 +74,13 @@ export const StatefulDocker = ({
         className={ dockingStyles.docker } 
         overflowMenuClassName={ readerSharedUI.dockerButton }
         prefs={ RSPrefs.docking }
-        aria-label={ Locale.reader.app.docker.wrapper }
+        aria-label={ locale.reader.app.docker.wrapper }
       />
 
       <ThCloseButton 
         ref={ ref }
         className={ readerSharedUI.dockerButton } 
-        aria-label={ Locale.reader.app.docker.close.trigger } 
+        aria-label={ locale.reader.app.docker.close.trigger } 
         onPress={ onClose }
         compounds={ {
           tooltipTrigger: {
@@ -89,7 +90,7 @@ export const StatefulDocker = ({
           tooltip: {
             className: readerSharedUI.tooltip
           },
-          label: Locale.reader.app.docker.close.tooltip
+          label: locale.reader.app.docker.close.tooltip
         }}
       />
     </Toolbar>

--- a/src/components/Docking/StatefulDockingWrapper.tsx
+++ b/src/components/Docking/StatefulDockingWrapper.tsx
@@ -2,7 +2,7 @@
 
 import { ReactNode, useCallback, useEffect, useRef } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import dockingStyles from "./assets/styles/docking.module.css";
 
@@ -38,7 +38,8 @@ const DockHandle = ({
   isPopulated: boolean;
   hasDragIndicator?: boolean;
 }) => {
-  const handleID = `${ flow }-resize-handle`;
+  const handleID = `${flow}-resize-handle`;
+  const locale = useLocale();
 
   const direction = useAppSelector(state => state.reader.direction);
 
@@ -90,27 +91,28 @@ const DockPanel = ({
   const dispatch = useAppDispatch();
 
   const dockClassName = flow === ThDockingKeys.end && direction === ThLayoutDirection.ltr ? "right-dock" : "left-dock";
-
+  const locale = useLocale();
+  
   const makeDockLabel = useCallback(() => {    
     let label = "";
     if (flow === ThDockingKeys.end && direction === ThLayoutDirection.ltr) {
-      label += Locale.reader.app.docking.dockingRight;
+      label += locale.reader.app.docking.dockingRight;
     } else {
-      label += Locale.reader.app.docking.dockingLeft
+      label += locale.reader.app.docking.dockingLeft
     }
 
     if (actionKey) {
       if (!isPopulated) {
-        const jsonTemplate = parseTemplate(Locale.reader.app.docking.dockingClosed);
+        const jsonTemplate = parseTemplate(locale.reader.app.docking.dockingClosed);
         // @ts-ignore
-        label += ` – ${ jsonTemplate({ action: Locale.reader[actionKey].heading }) }`
+        label += ` – ${ jsonTemplate({ action: locale.reader[actionKey].heading }) }`
       } else if (isCollapsed) {
-        const jsonTemplate = parseTemplate(Locale.reader.app.docking.dockingCollapsed);
+        const jsonTemplate = parseTemplate(locale.reader.app.docking.dockingCollapsed);
         // @ts-ignore
-        label += ` – ${ jsonTemplate({ action: Locale.reader[actionKey].heading }) }`
+        label += ` – ${ jsonTemplate({ action: locale.reader[actionKey].heading }) }`
       }
     } else {
-      label += ` – ${ Locale.reader.app.docking.dockingEmpty }`
+      label += ` – ${ locale.reader.app.docking.dockingEmpty }`
     }
 
     return label;

--- a/src/components/Epub/AppLocale.tsx
+++ b/src/components/Epub/AppLocale.tsx
@@ -19,16 +19,17 @@ interface AppLocaleProps {
 }
 
 export const AppLocale: React.FC<AppLocaleProps> = ({ locale, children }) => {
-  
+
   const { currentLocale, translations } = (() => {
     switch (locale) {
       case 'pl':
+      case 'PL':
         return { currentLocale: 'pl', translations: pl };
       default:
         return { currentLocale: 'en', translations: en };
     }
   })();
-  
+
   const value: AppLocaleContextType = {
     locale: currentLocale,
     translations

--- a/src/components/Epub/AppLocale.tsx
+++ b/src/components/Epub/AppLocale.tsx
@@ -6,35 +6,31 @@ import React, { createContext, useContext, ReactNode } from 'react';
 import en from '../../resources/locales/en.json';
 import pl from '../../resources/locales/pl.json';
 
-type SupportedLocale = 'en' | 'pl';
-
 interface AppLocaleContextType {
-  locale: SupportedLocale;
+  locale: string;
   translations: typeof en;
 }
 
 const AppLocaleContext = createContext<AppLocaleContextType | undefined>(undefined);
 
 interface AppLocaleProps {
-  locale: SupportedLocale;
+  locale?: string;
   children: ReactNode;
 }
 
 export const AppLocale: React.FC<AppLocaleProps> = ({ locale, children }) => {
-  const getTranslations = (locale: SupportedLocale) => {
+  
+  const { currentLocale, translations } = (() => {
     switch (locale) {
       case 'pl':
-        return pl;
-      case 'en':
+        return { currentLocale: 'pl', translations: pl };
       default:
-        return en;
+        return { currentLocale: 'en', translations: en };
     }
-  };
-
-  const translations = getTranslations(locale);
-
+  })();
+  
   const value: AppLocaleContextType = {
-    locale,
+    locale: currentLocale,
     translations
   };
 

--- a/src/components/Epub/AppLocale.tsx
+++ b/src/components/Epub/AppLocale.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import React, { createContext, useContext, ReactNode } from 'react';
+
+// Import locale files
+import en from '../../resources/locales/en.json';
+import pl from '../../resources/locales/pl.json';
+
+type SupportedLocale = 'en' | 'pl';
+
+interface AppLocaleContextType {
+  locale: SupportedLocale;
+  translations: typeof en;
+}
+
+const AppLocaleContext = createContext<AppLocaleContextType | undefined>(undefined);
+
+interface AppLocaleProps {
+  locale: SupportedLocale;
+  children: ReactNode;
+}
+
+export const AppLocale: React.FC<AppLocaleProps> = ({ locale, children }) => {
+  const getTranslations = (locale: SupportedLocale) => {
+    switch (locale) {
+      case 'pl':
+        return pl;
+      case 'en':
+      default:
+        return en;
+    }
+  };
+
+  const translations = getTranslations(locale);
+
+  const value: AppLocaleContextType = {
+    locale,
+    translations
+  };
+
+  return (
+    <AppLocaleContext.Provider value={value}>
+      {children}
+    </AppLocaleContext.Provider>
+  );
+};
+
+export const useLocale = () => {
+  const context = useContext(AppLocaleContext);
+  if (context === undefined) {
+    throw new Error('useLocale must be used within an AppLocale provider');
+  }
+  return context.translations;
+};

--- a/src/components/Epub/Settings/StatefulColumns.tsx
+++ b/src/components/Epub/Settings/StatefulColumns.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import React, { useCallback } from "react";
+import React, { use, useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import AutoLayoutIcon from "./assets/icons/document_scanner.svg";
 import OneColIcon from "./assets/icons/article.svg";
@@ -16,6 +16,8 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { setColumnCount } from "@/lib/settingsReducer";
 
 export const StatefulColumns = () => {
+  const locale = useLocale();
+
   const isScroll = useAppSelector(state => state.settings.scroll);
   const isFXL = useAppSelector(state => state.publication.isFXL);
   const columnCount = useAppSelector(state => state.settings.columnCount) || "auto";
@@ -36,7 +38,7 @@ export const StatefulColumns = () => {
     <>
     <StatefulRadioGroup 
       standalone={ true }
-      label={ Locale.reader.settings.column.title }
+      label={ locale.reader.settings.column.title }
       orientation="horizontal"
       value={ columnCount }
       onChange={ async (val: string) => await updatePreference(val) }
@@ -44,17 +46,17 @@ export const StatefulColumns = () => {
       items={[
         {
           icon: AutoLayoutIcon,
-          label: Locale.reader.settings.column.auto, 
+          label: locale.reader.settings.column.auto,
           value: "auto" 
         },
         {
           icon: OneColIcon,
-          label: Locale.reader.settings.column.one, 
+          label: locale.reader.settings.column.one,
           value: "1" 
         },
         {
           icon: TwoColsIcon,
-          label: Locale.reader.settings.column.two, 
+          label: locale.reader.settings.column.two, 
           value: "2" 
         }
       ]}

--- a/src/components/Epub/Settings/StatefulFontFamily.tsx
+++ b/src/components/Epub/Settings/StatefulFontFamily.tsx
@@ -2,7 +2,7 @@
 
 import { CSSProperties, Key, useCallback, useRef } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -19,10 +19,11 @@ import { setFontFamily } from "@/lib/settingsReducer";
 import { defaultFontFamilyOptions } from "@/preferences/models/const";
 
 export const StatefulFontFamily = ({ standalone = true }: StatefulSettingsItemProps) => {
+  const locale = useLocale();
   const fontFamily = useAppSelector(state => state.settings.fontFamily);
   const fontFamilyOptions = useRef(Object.entries(defaultFontFamilyOptions).map(([property, stack]) => ({
       id: property,
-      label: Locale.reader.settings.fontFamily.labels[property as keyof typeof Locale.reader.settings.fontFamily.labels],
+      label: locale.reader.settings.fontFamily.labels[property as keyof typeof locale.reader.settings.fontFamily.labels],
       value: stack
     }))
   );
@@ -54,10 +55,10 @@ export const StatefulFontFamily = ({ standalone = true }: StatefulSettingsItemPr
       { ...(standalone 
         ? { 
           className: settingsStyles.readerSettingsGroup,
-          label: Locale.reader.settings.fontFamily.title
+          label: locale.reader.settings.fontFamily.title
         } 
         : {
-          "aria-label": Locale.reader.settings.fontFamily.title
+          "aria-label": locale.reader.settings.fontFamily.title
         }) }
       selectedKey={ fontFamily }
       onSelectionChange={ async (key) => await updatePreference(key) }

--- a/src/components/Epub/Settings/StatefulFontWeight.tsx
+++ b/src/components/Epub/Settings/StatefulFontWeight.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 import { fontWeightRangeConfig } from "@readium/navigator";
@@ -18,6 +18,7 @@ export const StatefulFontWeight = ({ standalone = true }: StatefulSettingsItemPr
   const fontFamily = useAppSelector(state => state.settings.fontFamily);
   const fontWeight = useAppSelector(state => state.settings.fontWeight);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -31,7 +32,7 @@ export const StatefulFontWeight = ({ standalone = true }: StatefulSettingsItemPr
     <>
     <StatefulSlider
       standalone={ standalone }
-      label={ Locale.reader.settings.fontWeight.title }
+      label={ locale.reader.settings.fontWeight.title }
       defaultValue={ 400 } 
       value={ fontWeight } 
       onChange={ async(value) => await updatePreference(value as number) } 

--- a/src/components/Epub/Settings/StatefulHyphens.tsx
+++ b/src/components/Epub/Settings/StatefulHyphens.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 import { ThTextAlignOptions } from "@/preferences/models/enums";
@@ -18,6 +18,7 @@ import { setHyphens } from "@/lib/settingsReducer";
 export const StatefulHyphens = ({ standalone = true }: StatefulSettingsItemProps) => {
   const hyphens = useAppSelector(state => state.settings.hyphens);
   const textAlign = useAppSelector(state => state.settings.textAlign);
+  const locale = useLocale();
 
   const dispatch = useAppDispatch();
   
@@ -35,8 +36,8 @@ export const StatefulHyphens = ({ standalone = true }: StatefulSettingsItemProps
     <>
     <StatefulSwitch 
       standalone={ standalone }
-      heading={ Locale.reader.settings.hyphens.title }
-      label={ Locale.reader.settings.hyphens.label }
+      heading={ locale.reader.settings.hyphens.title }
+      label={ locale.reader.settings.hyphens.label }
       onChange={ async (isSelected: boolean) => await updatePreference(isSelected) }
       isSelected={ hyphens ?? false }
       isDisabled={ textAlign === ThTextAlignOptions.publisher }

--- a/src/components/Epub/Settings/StatefulLayout.tsx
+++ b/src/components/Epub/Settings/StatefulLayout.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { ThLayoutOptions } from "@/preferences/models/enums";
 
@@ -20,6 +20,7 @@ export const StatefulLayout = () => {
   const isScroll = useAppSelector(state => state.settings.scroll);
 
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences, handleScrollAffordances } = useEpubNavigator();
 
@@ -37,19 +38,19 @@ export const StatefulLayout = () => {
     <>
     <StatefulRadioGroup
       standalone={ true }
-      label={ Locale.reader.settings.layout.title }
+      label={ locale.reader.settings.layout.title }
       orientation="horizontal"
       value={ isScroll ? ThLayoutOptions.scroll : ThLayoutOptions.paginated }
       onChange={ async (val: string) => await updatePreference(val) }
       items={[
         {
           icon: PaginatedIcon,
-          label: Locale.reader.settings.layout.paginated,
+          label: locale.reader.settings.layout.paginated,
           value: ThLayoutOptions.paginated
         },
         {
           icon: ScrollableIcon,
-          label: Locale.reader.settings.layout.scrolled,
+          label: locale.reader.settings.layout.scrolled,
           value: ThLayoutOptions.scroll
         }
       ]} 

--- a/src/components/Epub/Settings/StatefulLetterSpacing.tsx
+++ b/src/components/Epub/Settings/StatefulLetterSpacing.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 
 import { defaultLetterSpacing, ThSettingsKeys, ThSettingsRangeVariant } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -26,6 +26,7 @@ export const StatefulLetterSpacing = ({ standalone = true }: StatefulSettingsIte
     step: RSPrefs.settings.keys?.[ThSettingsKeys.letterSpacing]?.step ?? defaultLetterSpacing.step
   };
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -43,15 +44,15 @@ export const StatefulLetterSpacing = ({ standalone = true }: StatefulSettingsIte
     { letterSpacingRangeConfig.variant === ThSettingsRangeVariant.numberField 
       ? <StatefulNumberField 
         standalone={ standalone }
-        label={ Locale.reader.settings.letterSpacing.title }
+        label={ locale.reader.settings.letterSpacing.title }
         defaultValue={ 0 } 
         value={ letterSpacing || 0 } 
         onChange={ async(value) => await updatePreference(value) } 
         range={ letterSpacingRangeConfig.range }
         step={ letterSpacingRangeConfig.step }
         steppers={{
-          decrementLabel: Locale.reader.settings.letterSpacing.decrease,
-          incrementLabel: Locale.reader.settings.letterSpacing.increase
+          decrementLabel: locale.reader.settings.letterSpacing.decrease,
+          incrementLabel: locale.reader.settings.letterSpacing.increase
         }}
         formatOptions={{ style: "percent" }} 
         isWheelDisabled={ true }
@@ -59,7 +60,7 @@ export const StatefulLetterSpacing = ({ standalone = true }: StatefulSettingsIte
       />
       : <StatefulSlider
         standalone={ standalone }
-        label={ Locale.reader.settings.letterSpacing.title }
+        label={ locale.reader.settings.letterSpacing.title }
         defaultValue={ 0 } 
         value={ letterSpacing || 0 } 
         onChange={ async(value) => await updatePreference(value as number) } 

--- a/src/components/Epub/Settings/StatefulLineHeight.tsx
+++ b/src/components/Epub/Settings/StatefulLineHeight.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useRef } from "react";
 
 import { defaultLineHeights, ThLineHeightOptions, ThSettingsKeys } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -26,6 +26,7 @@ export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemPr
   const publisherStyles = useAppSelector(state => state.settings.publisherStyles);
   const lineHeight = useAppSelector(state => state.settings.lineHeight);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -56,29 +57,29 @@ export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemPr
     <>
     <StatefulRadioGroup 
       standalone={ standalone }
-      label={ Locale.reader.settings.lineHeight.title }
+      label={ locale.reader.settings.lineHeight.title }
       orientation="horizontal"
       value={ publisherStyles ? ThLineHeightOptions.publisher : lineHeight } 
       onChange={ async (val: string) => await updatePreference(val) }
       items={[
         {
           icon: BookIcon,
-          label: Locale.reader.settings.lineHeight.publisher, 
+          label: locale.reader.settings.lineHeight.publisher,
           value: ThLineHeightOptions.publisher 
         },
         {
           icon: SmallIcon,
-          label: Locale.reader.settings.lineHeight.small, 
+          label: locale.reader.settings.lineHeight.small,
           value: ThLineHeightOptions.small 
         },
         {
           icon: MediumIcon,
-          label: Locale.reader.settings.lineHeight.medium, 
+          label: locale.reader.settings.lineHeight.medium,
           value: ThLineHeightOptions.medium 
         },
         {
           icon: LargeIcon,
-          label: Locale.reader.settings.lineHeight.large, 
+          label: locale.reader.settings.lineHeight.large,
           value: ThLineHeightOptions.large 
         },
       ]}

--- a/src/components/Epub/Settings/StatefulParagraphIndent.tsx
+++ b/src/components/Epub/Settings/StatefulParagraphIndent.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 
 import { defaultParagraphIndent, ThSettingsKeys, ThSettingsRangeVariant } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -26,6 +26,7 @@ export const StatefulParagraphIndent = ({ standalone = true }: StatefulSettingsI
       step: RSPrefs.settings.keys?.[ThSettingsKeys.paragraphIndent]?.step ?? defaultParagraphIndent.step
     };
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -43,15 +44,15 @@ export const StatefulParagraphIndent = ({ standalone = true }: StatefulSettingsI
     { paragraphIndentRangeConfig.variant === ThSettingsRangeVariant.numberField 
       ? <StatefulNumberField 
         standalone={ standalone }
-        label={ Locale.reader.settings.paraIndent.title }
+        label={ locale.reader.settings.paraIndent.title }
         defaultValue={ 0 } 
         value={ paragraphIndent || 0 } 
         onChange={ async(value) => await updatePreference(value) } 
         range={ paragraphIndentRangeConfig.range }
         step={ paragraphIndentRangeConfig.step }
         steppers={{
-          decrementLabel: Locale.reader.settings.paraIndent.decrease,
-          incrementLabel: Locale.reader.settings.paraIndent.increase
+          decrementLabel: locale.reader.settings.paraIndent.decrease,
+          incrementLabel: locale.reader.settings.paraIndent.increase
         }}
         formatOptions={{
           signDisplay: "exceptZero",
@@ -63,7 +64,7 @@ export const StatefulParagraphIndent = ({ standalone = true }: StatefulSettingsI
       />
       : <StatefulSlider
         standalone={ standalone }
-        label={ Locale.reader.settings.paraIndent.title }
+        label={ locale.reader.settings.paraIndent.title }
         defaultValue={ 0 } 
         value={ paragraphIndent || 0 } 
         onChange={ async(value) => await updatePreference(value as number) } 

--- a/src/components/Epub/Settings/StatefulParagraphSpacing.tsx
+++ b/src/components/Epub/Settings/StatefulParagraphSpacing.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 
 import { defaultParagraphSpacing, ThSettingsKeys, ThSettingsRangeVariant } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -26,6 +26,7 @@ export const StatefulParagraphSpacing = ({ standalone = true }: StatefulSettings
     step: RSPrefs.settings.keys?.[ThSettingsKeys.paragraphSpacing]?.step ?? defaultParagraphSpacing.step
   };
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -43,15 +44,15 @@ export const StatefulParagraphSpacing = ({ standalone = true }: StatefulSettings
     { paragraphSpacingRangeConfig.variant === ThSettingsRangeVariant.numberField 
       ? <StatefulNumberField 
         standalone={ standalone }
-        label={ Locale.reader.settings.paraSpacing.title }
+        label={ locale.reader.settings.paraSpacing.title }
         defaultValue={ 0 } 
         value={ paragraphSpacing || 0 } 
         onChange={ async(value) => await updatePreference(value) } 
         range={ paragraphSpacingRangeConfig.range }
         step={ paragraphSpacingRangeConfig.step }
         steppers={{
-          decrementLabel: Locale.reader.settings.paraSpacing.decrease,
-          incrementLabel: Locale.reader.settings.paraSpacing.increase
+          decrementLabel: locale.reader.settings.paraSpacing.decrease,
+          incrementLabel: locale.reader.settings.paraSpacing.increase
         }}
         formatOptions={{
           signDisplay: "exceptZero",
@@ -63,7 +64,7 @@ export const StatefulParagraphSpacing = ({ standalone = true }: StatefulSettings
       />
       : <StatefulSlider
         standalone={ standalone }
-        label={ Locale.reader.settings.paraSpacing.title }
+        label={ locale.reader.settings.paraSpacing.title }
         defaultValue={ 0 } 
         value={ paragraphSpacing || 0 } 
         onChange={ async(value) => await updatePreference(value as number) } 

--- a/src/components/Epub/Settings/StatefulPublisherStyles.tsx
+++ b/src/components/Epub/Settings/StatefulPublisherStyles.tsx
@@ -4,7 +4,7 @@ import { useCallback, useRef } from "react";
 
 import { defaultLineHeights, ThLineHeightOptions, ThSettingsKeys } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -27,6 +27,7 @@ export const StatefulPublisherStyles = ({ standalone = true }: StatefulSettingsI
   const wordSpacing = useAppSelector(state => state.settings.wordSpacing);
 
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const lineHeightOptions = useRef({
     [ThLineHeightOptions.publisher]: null,
@@ -64,7 +65,7 @@ export const StatefulPublisherStyles = ({ standalone = true }: StatefulSettingsI
     <>
     <StatefulSwitch 
       standalone={ standalone }
-      label={ Locale.reader.settings.publisherStyles.label }
+      label={ locale.reader.settings.publisherStyles.label }
       onChange={ async (isSelected: boolean) => await updatePreference(isSelected) }
       isSelected={ publisherStyles }
     />

--- a/src/components/Epub/Settings/StatefulSpacingGroup.tsx
+++ b/src/components/Epub/Settings/StatefulSpacingGroup.tsx
@@ -9,7 +9,7 @@ import {
   ThSpacingSettingsKeys 
 } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulGroupWrapper } from "../../Settings/StatefulGroupWrapper";
 
@@ -23,6 +23,7 @@ export const StatefulSpacingGroup = () => {
   const RSPrefs = usePreferences();
   const { spacingSettingsComponentsMap } = usePlugins();
   const dispatch = useAppDispatch();
+  const locale = useLocale();
   
   const setSpacingContainer = useCallback(() => {
     dispatch(setSettingsContainer(ThSettingsContainerKeys.spacing));
@@ -31,9 +32,9 @@ export const StatefulSpacingGroup = () => {
   return (
     <>
     <StatefulGroupWrapper 
-      heading={ Locale.reader.settings.spacing.title }
-      moreLabel={ Locale.reader.settings.spacing.advanced.trigger }
-      moreTooltip={ Locale.reader.settings.spacing.advanced.tooltip }
+      heading={ locale.reader.settings.spacing.title }
+      moreLabel={ locale.reader.settings.spacing.advanced.trigger }
+      moreTooltip={ locale.reader.settings.spacing.advanced.tooltip }
       onPressMore={ setSpacingContainer }
       componentsMap={ spacingSettingsComponentsMap }
       prefs={ RSPrefs.settings.spacing }

--- a/src/components/Epub/Settings/StatefulTextAlign.tsx
+++ b/src/components/Epub/Settings/StatefulTextAlign.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { ThTextAlignOptions } from "@/preferences/models/enums";
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
@@ -24,6 +24,7 @@ export const StatefulTextAlign = ({ standalone = true }: StatefulSettingsItemPro
   const isRTL = useAppSelector(state => state.publication.isRTL);
   const textAlign = useAppSelector(state => state.settings.textAlign);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -56,24 +57,24 @@ export const StatefulTextAlign = ({ standalone = true }: StatefulSettingsItemPro
     <>
     <StatefulRadioGroup 
       standalone={ standalone } 
-      label={ Locale.reader.settings.align.title }
+      label={ locale.reader.settings.align.title }
       orientation="horizontal" 
       value={ textAlign } 
       onChange={ async (val: string) => await updatePreference(val) }
       items={[
         {
           icon: BookIcon,
-          label: Locale.reader.settings.align.publisher, 
+          label: locale.reader.settings.align.publisher,
           value: ThTextAlignOptions.publisher 
         },
         {
           icon: isRTL ? RightAlignIcon : LeftAlignIcon,
-          label: isRTL ? Locale.reader.settings.align.right : Locale.reader.settings.align.left, 
+          label: isRTL ? locale.reader.settings.align.right : locale.reader.settings.align.left,
           value: ThTextAlignOptions.start 
         },
         {
           icon: JustifyIcon,
-          label: Locale.reader.settings.align.justify, 
+          label: locale.reader.settings.align.justify,
           value: ThTextAlignOptions.justify 
         }
       ]}

--- a/src/components/Epub/Settings/StatefulTextGroup.tsx
+++ b/src/components/Epub/Settings/StatefulTextGroup.tsx
@@ -9,7 +9,7 @@ import {
   ThTextSettingsKeys 
 } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulGroupWrapper } from "../../Settings/StatefulGroupWrapper";
 
@@ -23,6 +23,7 @@ export const StatefulTextGroup = () => {
   const RSPrefs = usePreferences();
   const { textSettingsComponentsMap } = usePlugins();
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const setTextContainer = useCallback(() => {
     dispatch(setSettingsContainer(ThSettingsContainerKeys.text));
@@ -31,9 +32,9 @@ export const StatefulTextGroup = () => {
   return(
     <>
     <StatefulGroupWrapper 
-      heading={ Locale.reader.settings.text.title }
-      moreLabel={ Locale.reader.settings.text.advanced.trigger }
-      moreTooltip={ Locale.reader.settings.text.advanced.tooltip }
+      heading={ locale.reader.settings.text.title }
+      moreLabel={ locale.reader.settings.text.advanced.trigger }
+      moreTooltip={ locale.reader.settings.text.advanced.tooltip }
       onPressMore={ setTextContainer }
       componentsMap={ textSettingsComponentsMap }
       prefs={ RSPrefs.settings.text }

--- a/src/components/Epub/Settings/StatefulTextNormalize.tsx
+++ b/src/components/Epub/Settings/StatefulTextNormalize.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -16,6 +16,7 @@ import { setTextNormalization } from "@/lib/settingsReducer";
 export const StatefulTextNormalize = ({ standalone = true }: StatefulSettingsItemProps) => {
   const textNormalization = useAppSelector(state => state.settings.textNormalization);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -29,8 +30,8 @@ export const StatefulTextNormalize = ({ standalone = true }: StatefulSettingsIte
     <>
     <StatefulSwitch 
       standalone={ standalone }
-      heading={ Locale.reader.settings.normalizeText.title }
-      label={ Locale.reader.settings.normalizeText.label }
+      heading={ locale.reader.settings.normalizeText.title }
+      label={ locale.reader.settings.normalizeText.label }
       onChange={ async (isSelected: boolean) => await updatePreference(isSelected) }
       isSelected={ textNormalization ?? false }
     />

--- a/src/components/Epub/Settings/StatefulTheme.tsx
+++ b/src/components/Epub/Settings/StatefulTheme.tsx
@@ -4,7 +4,8 @@ import React, { useCallback, useEffect, useRef } from "react";
 
 import { ThemeKeyType, usePreferenceKeys } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
+
 import settingsStyles from "../../Settings/assets/styles/settings.module.css";
 
 import CheckIcon from "./assets/icons/check.svg";
@@ -51,6 +52,7 @@ export const StatefulTheme = ({ mapArrowNav }: { mapArrowNav?: number }) => {
   );
 
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { submitPreferences } = useEpubNavigator();
 
@@ -160,7 +162,7 @@ export const StatefulTheme = ({ mapArrowNav }: { mapArrowNav?: number }) => {
     <StatefulRadioGroup
       ref={ radioGroupRef }
       standalone={ true }
-      label={ Locale.reader.settings.themes.title }
+      label={ locale.reader.settings.themes.title }
       value={ theme }
       onChange={ async (val) => await updatePreference(val as ThemeKeyType) }
     >
@@ -180,8 +182,8 @@ export const StatefulTheme = ({ mapArrowNav }: { mapArrowNav?: number }) => {
             } : {}) }
           >
           <span>
-            { t in Locale.reader.settings.themes 
-              ? Locale.reader.settings.themes[t as keyof typeof Locale.reader.settings.themes]
+            { t in locale.reader.settings.themes
+              ? locale.reader.settings.themes[t as keyof typeof locale.reader.settings.themes]
               : t
             } 
             { t === theme ? <CheckIcon aria-hidden="true" focusable="false" /> : <></> }

--- a/src/components/Epub/Settings/StatefulWordSpacing.tsx
+++ b/src/components/Epub/Settings/StatefulWordSpacing.tsx
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 
 import { defaultWordSpacing, ThSettingsKeys, ThSettingsRangeVariant } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import { StatefulSettingsItemProps } from "../../Settings/models/settings";
 
@@ -26,6 +26,7 @@ export const StatefulWordSpacing = ({ standalone = true }: StatefulSettingsItemP
     step: RSPrefs.settings.keys?.[ThSettingsKeys.wordSpacing]?.step ?? defaultWordSpacing.step
   };
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const { getSetting, submitPreferences } = useEpubNavigator();
 
@@ -43,15 +44,15 @@ export const StatefulWordSpacing = ({ standalone = true }: StatefulSettingsItemP
     { wordSpacingRangeConfig.variant === ThSettingsRangeVariant.numberField 
       ? <StatefulNumberField 
         standalone={ standalone }
-        label={ Locale.reader.settings.wordSpacing.title }
+        label={ locale.reader.settings.wordSpacing.title }
         defaultValue={ 0 } 
         value={ wordSpacing || 0 } 
         onChange={ async(value) => await updatePreference(value) } 
         range={ wordSpacingRangeConfig.range }
         step={ wordSpacingRangeConfig.step }
         steppers={{
-          decrementLabel: Locale.reader.settings.wordSpacing.decrease,
-          incrementLabel: Locale.reader.settings.wordSpacing.increase
+          decrementLabel: locale.reader.settings.wordSpacing.decrease,
+          incrementLabel: locale.reader.settings.wordSpacing.increase
         }}
         formatOptions={{ style: "percent" }} 
         isWheelDisabled={ true }
@@ -59,7 +60,7 @@ export const StatefulWordSpacing = ({ standalone = true }: StatefulSettingsItemP
       />
       : <StatefulSlider
         standalone={ standalone }
-        label={ Locale.reader.settings.wordSpacing.title }
+        label={ locale.reader.settings.wordSpacing.title }
         defaultValue={ 0 } 
         value={ wordSpacing || 0 } 
         onChange={ async(value) => await updatePreference(value as number) } 

--- a/src/components/Epub/Settings/StatefulZoom.tsx
+++ b/src/components/Epub/Settings/StatefulZoom.tsx
@@ -4,7 +4,7 @@ import React, { useCallback } from "react";
 
 import { defaultFontSize, ThSettingsKeys, ThSettingsRangeVariant } from "@/preferences";
 
-import Locale from "../../../resources/locales/en.json";
+import { useLocale } from "../AppLocale";
 
 import Decrease from "./assets/icons/text_decrease.svg";
 import Increase from "./assets/icons/text_increase.svg";
@@ -25,6 +25,7 @@ export const StatefulZoom = () => {
   const fontSize = useAppSelector((state) => state.settings.fontSize);
   const isFXL = useAppSelector((state) => state.publication.isFXL);
   const dispatch = useAppDispatch();
+  const locale = useLocale();
   
   const { 
     getSetting, 
@@ -71,14 +72,14 @@ export const StatefulZoom = () => {
         defaultValue={ 1 } 
         value={ fontSize } 
         onChange={ async(value) => await updatePreference(value) } 
-        label={ isFXL ? Locale.reader.settings.zoom.title : Locale.reader.settings.fontSize.title }
+        label={ isFXL ? locale.reader.settings.zoom.title : locale.reader.settings.fontSize.title }
         range={ zoomRangeConfig.range }
         step={ zoomRangeConfig.step }
         steppers={{
           decrementIcon: isFXL ? ZoomOut : Decrease,
-          decrementLabel: isFXL ? Locale.reader.settings.zoom.decrease : Locale.reader.settings.fontSize.decrease,
+          decrementLabel: isFXL ? locale.reader.settings.zoom.decrease : locale.reader.settings.fontSize.decrease,
           incrementIcon: isFXL ? ZoomIn : Increase,
-          incrementLabel: isFXL ? Locale.reader.settings.zoom.increase : Locale.reader.settings.fontSize.increase
+          incrementLabel: isFXL ? locale.reader.settings.zoom.increase : locale.reader.settings.fontSize.increase
         }}
         formatOptions={{ style: "percent" }} 
         isWheelDisabled={ true }
@@ -89,7 +90,7 @@ export const StatefulZoom = () => {
         defaultValue={ 1 } 
         value={ fontSize } 
         onChange={ async(value) => await updatePreference(value as number) } 
-        label={ isFXL ? Locale.reader.settings.zoom.title : Locale.reader.settings.fontSize.title }
+        label={ isFXL ? locale.reader.settings.zoom.title : locale.reader.settings.fontSize.title }
         range={ zoomRangeConfig.range }
         step={ zoomRangeConfig.step }
         formatOptions={{ style: "percent" }} 

--- a/src/components/Epub/StatefulReader.tsx
+++ b/src/components/Epub/StatefulReader.tsx
@@ -832,11 +832,7 @@ export const StatefulReader = ({
   // Same for arrows and collapsible actions.
   if (!breakpoint) return null;
 
-  function normalizeToArray(input: string | string[] | null): string[] {
-    if (input == null) return [];
-    return Array.isArray(input) ? input : [input];
-  }
-  const bookLocale = rawManifest.metadata ? normalizeToArray(rawManifest.metadata.language)[0] : null;
+  const bookLocale = publication.current?.metadata.languages?.at(0)
 
   return (
     <>

--- a/src/components/Epub/StatefulReader.tsx
+++ b/src/components/Epub/StatefulReader.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../preferences";
 
 import Locale from "../../resources/locales/en.json";
+import { AppLocale } from "./AppLocale";
 
 import "../assets/styles/reader.css";
 import arrowStyles from "../assets/styles/readerArrowButton.module.css";
@@ -112,6 +113,7 @@ import { getPlatformModifier } from "@/core/Helpers/keyboardUtilities";
 import { createTocTree, TocItem } from "@/helpers/createTocTree";
 import { deserializePositions } from "@/helpers/deserializePositions";
 import { propsToCSSVars } from "@/core/Helpers/propsToCSSVars";
+import App from "next/app";
 
 export interface ReadiumCSSSettings {
   columnCount: string;
@@ -832,7 +834,8 @@ export const StatefulReader = ({
 
   return (
     <>
-    <I18nProvider locale={ RSPrefs.locale }>
+    <I18nProvider locale={RSPrefs.locale}>
+    <AppLocale locale={RSPrefs.locale}>
     <ThPluginProvider>
       <main>
         <StatefulDockingWrapper>
@@ -880,6 +883,7 @@ export const StatefulReader = ({
       </StatefulDockingWrapper>
     </main>
   </ThPluginProvider>
+  </AppLocale>
   </I18nProvider>
   </>
 )};

--- a/src/components/Epub/StatefulReader.tsx
+++ b/src/components/Epub/StatefulReader.tsx
@@ -832,10 +832,16 @@ export const StatefulReader = ({
   // Same for arrows and collapsible actions.
   if (!breakpoint) return null;
 
+  function normalizeToArray(input: string | string[] | null): string[] {
+    if (input == null) return [];
+    return Array.isArray(input) ? input : [input];
+  }
+  const bookLocale = rawManifest.metadata ? normalizeToArray(rawManifest.metadata.language)[0] : null;
+
   return (
     <>
     <I18nProvider locale={RSPrefs.locale}>
-    <AppLocale locale={RSPrefs.locale}>
+    <AppLocale locale={bookLocale || RSPrefs.locale}>
     <ThPluginProvider>
       <main>
         <StatefulDockingWrapper>

--- a/src/components/Sheets/StatefulBottomSheet.tsx
+++ b/src/components/Sheets/StatefulBottomSheet.tsx
@@ -4,7 +4,7 @@ import React, { CSSProperties, KeyboardEvent, useCallback, useMemo, useRef } fro
 
 import { ThBottomSheetDetent, ThSheetHeaderVariant } from "@/preferences";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import { StatefulSheet } from "./models/sheets";
 
@@ -52,6 +52,7 @@ export const StatefulBottomSheet = ({
   dismissEscapeKeyClose
 }: StatefulBottomSheetProps) => {
   const RSPrefs = usePreferences();
+  const locale = useLocale();
   const direction = useAppSelector((state) => state.reader.direction);
   const prefersReducedMotion = useAppSelector(state => state.theming.prefersReducedMotion);
 
@@ -314,16 +315,16 @@ export const StatefulBottomSheet = ({
         { headerVariant === ThSheetHeaderVariant.previous 
             ? <ThNavigationButton 
               direction={ direction === "ltr" ? "left" : "right" }
-              label={ Locale.reader.app.back.trigger }
+              label={ locale.reader.app.back.trigger }
               ref={ bottomSheetCloseRef }
               className={ classNames(className, readerSharedUI.backButton) } 
-              aria-label={ Locale.reader.app.back.trigger }
+              aria-label={ locale.reader.app.back.trigger }
               onPress={ onClosePress }
             /> 
             : <ThCloseButton
               ref={ bottomSheetCloseRef }
               className={ readerSharedUI.closeButton } 
-              aria-label={ Locale.reader.app.docker.close.trigger } 
+              aria-label={ locale.reader.app.docker.close.trigger } 
               onPress={ onClosePress }
             />
           }

--- a/src/components/Sheets/StatefulDockedSheet.tsx
+++ b/src/components/Sheets/StatefulDockedSheet.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useRef } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import { StatefulSheet } from "./models/sheets";
 import { ThDockingKeys, ThSheetHeaderVariant, ThLayoutDirection } from "@/preferences/models/enums";
@@ -43,6 +43,7 @@ export const StatefulDockedSheet = ({
   const dockedSheetCloseRef = useRef<HTMLButtonElement | null>(null);
 
   const direction = useAppSelector(state => state.reader.direction);
+  const locale = useLocale();
 
   const classFromFlow = useCallback(() => {
     if (flow === ThDockingKeys.start) {
@@ -83,10 +84,10 @@ export const StatefulDockedSheet = ({
           { headerVariant === ThSheetHeaderVariant.previous 
             ? <ThNavigationButton
               direction={ direction === "ltr" ? "left" : "right" } 
-              label={ Locale.reader.app.back.trigger }
+              label={ locale.reader.app.back.trigger }
               ref={ dockedSheetCloseRef }
               className={ classNames(className, readerSharedUI.backButton) } 
-              aria-label={ Locale.reader.app.back.trigger }
+              aria-label={ locale.reader.app.back.trigger }
               onPress={ onClosePress }
             /> 
             : <StatefulDocker 

--- a/src/components/Sheets/StatefulFullScreenSheet.tsx
+++ b/src/components/Sheets/StatefulFullScreenSheet.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import { StatefulSheet } from "./models/sheets";
 import { ThSheetHeaderVariant } from "@/preferences/models/enums";
@@ -38,6 +38,7 @@ export const StatefulFullScreenSheet = ({
   const fullScreenHeaderRef = useRef<HTMLDivElement | null>(null);
   const fullScreenBodyRef = useRef<HTMLDivElement | null>(null);
   const fullScreenCloseRef = useRef<HTMLButtonElement | null>(null);
+  const locale = useLocale();
 
   if (React.Children.toArray(children).length > 0) {
     return(
@@ -77,16 +78,16 @@ export const StatefulFullScreenSheet = ({
           { headerVariant === ThSheetHeaderVariant.previous
               ? <ThNavigationButton
                 direction={ direction === "ltr" ? "left" : "right" }
-                label={ Locale.reader.app.back.trigger }
+                label={ locale.reader.app.back.trigger }
                 ref={ fullScreenCloseRef }
                 className={ classNames(className, readerSharedUI.backButton) } 
-                aria-label={ Locale.reader.app.back.trigger }
+                aria-label={ locale.reader.app.back.trigger }
                 onPress={ onClosePress }
               />
               : <ThCloseButton
                 ref={ fullScreenCloseRef }
                 className={ readerSharedUI.closeButton } 
-                aria-label={ Locale.reader.app.docker.close.trigger } 
+                aria-label={ locale.reader.app.docker.close.trigger } 
                 onPress={ onClosePress }
               />
             }

--- a/src/components/Sheets/StatefulPopoverSheet.tsx
+++ b/src/components/Sheets/StatefulPopoverSheet.tsx
@@ -2,7 +2,7 @@
 
 import React, { useRef } from "react";
 
-import Locale from "../../resources/locales/en.json";
+import { useLocale } from "../Epub/AppLocale";
 
 import { StatefulSheet } from "./models/sheets";
 import { ThSheetHeaderVariant } from "@/preferences/models/enums";
@@ -47,6 +47,7 @@ export const StatefulPopoverSheet = ({
   const popoverHeaderRef = useRef<HTMLDivElement | null>(null);
   const popoverBodyRef = useRef<HTMLDivElement | null>(null);
   const popoverCloseRef = useRef<HTMLButtonElement | null>(null);
+  const locale = useLocale();
 
   if (React.Children.toArray(children).length > 0) {
     return(
@@ -87,10 +88,10 @@ export const StatefulPopoverSheet = ({
           { headerVariant === ThSheetHeaderVariant.previous 
             ? <ThNavigationButton 
                 direction={ direction === "ltr" ? "left" : "right" }
-                label={ Locale.reader.app.back.trigger }
+                label={ locale.reader.app.back.trigger }
                 ref={ popoverCloseRef }
                 className={ classNames(className, readerSharedUI.backButton) } 
-                aria-label={ Locale.reader.app.back.trigger }
+                aria-label={ locale.reader.app.back.trigger }
                 onPress={ onClosePress }
               />
               : <StatefulDocker 

--- a/src/components/StatefulReaderArrowButton.tsx
+++ b/src/components/StatefulReaderArrowButton.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useRef, useState } from "react";
 
-import Locale from "../resources/locales/en.json";
+import { useLocale } from "./Epub/AppLocale";
 
 import arrowStyles from "./assets/styles/readerArrowButton.module.css";
 import readerSharedUI from "./assets/styles/readerSharedUI.module.css";
@@ -34,6 +34,7 @@ export const StatefulReaderArrowButton = ({
   onPress,
   ...props
 }: StatefulReaderArrowButtonProps) => {
+  const locale = useLocale();
   const RSPrefs = usePreferences();
   
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -55,8 +56,8 @@ export const StatefulReaderArrowButton = ({
     direction === "right" && !isRTL || 
     direction === "left" && isRTL
   ) 
-    ? Locale.reader.navigation.goForward 
-    : Locale.reader.navigation.goBackward;
+    ? locale.reader.navigation.goForward 
+    : locale.reader.navigation.goBackward;
 
   const handleClassNameFromState = () => {
     let className = "";

--- a/src/components/StatefulReaderFooter.tsx
+++ b/src/components/StatefulReaderFooter.tsx
@@ -2,8 +2,7 @@
 
 import React from "react";
 
-import Locale from "../resources/locales/en.json";
-
+import { useLocale } from "./Epub/AppLocale"
 import { setHovering } from "@/lib/readerReducer";
 import { useAppDispatch } from "@/lib/hooks";
 
@@ -12,6 +11,7 @@ import { StatefulReaderProgression } from "./StatefulReaderProgression";
 
 export const StatefulReaderFooter = () => {
   const dispatch = useAppDispatch();
+  const locale = useLocale();
 
   const setHover = () => {
     dispatch(setHovering(true));
@@ -25,7 +25,7 @@ export const StatefulReaderFooter = () => {
     <>
     <ThFooter 
       id="bottom-bar" 
-      aria-label={ Locale.reader.app.footer.label } 
+      aria-label={ locale.reader.app.footer.label } 
       onMouseEnter={ setHover } 
       onMouseLeave={ removeHover }
     >

--- a/src/components/StatefulReaderHeader.tsx
+++ b/src/components/StatefulReaderHeader.tsx
@@ -4,7 +4,7 @@ import React, { useCallback } from "react";
 
 import { ActionKeyType, usePreferenceKeys } from "@/preferences";
 
-import Locale from "../resources/locales/en.json";
+import { useLocale } from "./Epub/AppLocale";
 
 import readerHeaderStyles from "./assets/styles/readerHeader.module.css";
 
@@ -20,6 +20,7 @@ import { setHovering } from "@/lib/readerReducer";
 import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 
 export const StatefulReaderHeader = () => {
+  const locale = useLocale();
   const { reflowActionKeys, fxlActionKeys } = usePreferenceKeys();
   const RSPrefs = usePreferences();
   const { actionsComponentsMap } = usePlugins();
@@ -65,14 +66,14 @@ export const StatefulReaderHeader = () => {
     <ThHeader 
       className={ readerHeaderStyles.header } 
       id="top-bar" 
-      aria-label={ Locale.reader.app.header.label } 
+      aria-label={ locale.reader.app.header.label } 
       onMouseEnter={ setHover } 
       onMouseLeave={ removeHover }
     >
       <ThRunningHead 
-        label={ runningHead || Locale.reader.app.header.runningHeadFallback } 
+        label={ runningHead || locale.reader.app.header.runningHeadFallback } 
         syncDocTitle={ true }
-        aria-label={ Locale.reader.app.header.runningHead }
+        aria-label={ locale.reader.app.header.runningHead }
       />
       
       <StatefulCollapsibleActionsBar 
@@ -80,7 +81,7 @@ export const StatefulReaderHeader = () => {
         items={ listActionItems() }
         prefs={{ ...RSPrefs.actions, displayOrder: isFXL ? RSPrefs.actions.fxlOrder : RSPrefs.actions.reflowOrder }}
         className={ readerHeaderStyles.actionsWrapper } 
-        aria-label={ Locale.reader.app.header.actions } 
+        aria-label={ locale.reader.app.header.actions } 
         overflowActionCallback={ (isImmersive && !isHovering) }
         overflowMenuDisplay={ (!isImmersive || isHovering) }
       />

--- a/src/components/StatefulReaderProgression.tsx
+++ b/src/components/StatefulReaderProgression.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 
-import Locale from "../resources/locales/en.json";
+import { useLocale } from "./Epub/AppLocale";
 import progressionStyles from "./assets/styles/readerProgression.module.css";
 
 import { ThProgression } from "@/core/Components/Reader/ThProgression";
@@ -21,7 +21,9 @@ export interface UnstableProgressionObject {
 }
 
 export const StatefulReaderProgression = () => {
-  const jsonTemplate = parseTemplate(Locale.reader.app.progression.of);
+  const locale = useLocale();
+
+  const jsonTemplate = parseTemplate(locale.reader.app.progression.of);
   const progression: UnstableProgressionObject = useAppSelector(state => state.publication.progression);
 
   const [current, setCurrent] = useState("");
@@ -48,7 +50,7 @@ export const StatefulReaderProgression = () => {
     {( current && reference ) 
     && <ThProgression 
       id={ progressionStyles.current } 
-      aria-label={ Locale.reader.app.progression.wrapper }
+      aria-label={ locale.reader.app.progression.wrapper }
     >
       { jsonTemplate({ current: current, reference: reference }) }
     </ThProgression>}

--- a/src/resources/locales/pl.json
+++ b/src/resources/locales/pl.json
@@ -1,0 +1,249 @@
+{
+  "bookUrlConverter": {
+    "label": "Wczytaj publikację EPUB ze zdalnego serwera (musi obsługiwać żądania zakresu bajtów):",
+    "placeholder": "https://www.example.org/ebook.epub",
+    "button": "Wczytaj",
+    "error": "URL jest nieprawidłowy. Sprawdź poprawność adresu URL i spróbuj ponownie."
+  },
+  "reader": {
+    "app": {
+      "loading": "Ładuję...",
+      "publicationWrapper": "Jesteś teraz w publikacji.",
+      "docking": {
+        "dockingLeft": "Panel zadokowany po lewej",
+        "dockingRight": "Panel zadokowany po prawej",
+        "dockingEmpty": "Aktualnie pusty",
+        "dockingClosed": "Jest zamknięty, zawiera {{ action }}",
+        "dockingCollapsed": "Jest zwinięty, zawiera {{ action }}"
+      },
+      "header": {
+        "label": "Górny pasek",
+        "runningHead": "Nagłówek bieżący",
+        "runningHeadFallback": "...",
+        "actions": "Akcje"
+      },
+      "footer": {
+        "label": "Dolny pasek"
+      },
+      "progression": {
+        "wrapper": "Aktualny postęp",
+        "of": "{{ current }} z {{ reference }}",
+        "referenceFallback": "bieżący rozdział",
+        "pubFallback": "publikacja"
+      },
+      "docker": {
+        "wrapper": "Opcje dokowania",
+        "dockToLeft": {
+          "trigger": "Zadokuj po lewej stronie",
+          "tooltip": "Dokuj po lewej stronie"
+        },
+        "dockToRight": {
+          "trigger": "Zadokuj po prawej stronie",
+          "tooltip": "Dokuj po prawej stronie"
+        },
+        "popover": {
+          "trigger": "Wyświetl w oknie",
+          "tooltip": "Wyskakujące okno"
+        },
+        "fullscreen": {
+          "trigger": "Wyświetl na treści",
+          "tooltip": "Nakładka"
+        },
+        "close": {
+          "trigger": "Zamknij",
+          "tooltip": "Zamknij"
+        }
+      },
+      "back": {
+        "trigger": "Wróć"
+      }
+    },
+    "navigation": {
+      "goForward": "Do przodu",
+      "goBackward": "Do tyłu",
+      "scroll": {
+        "wrapper": "Nawiguj przez publikację",
+        "prevLabel": "Poprzedni",
+        "nextLabel": "Następny",
+        "prevA11yLabel": "Przejdź do poprzedniego zasobu",
+        "nextA11yLabel": "Przejdź do następnego zasobu"
+      }
+    },
+    "fullscreen": {
+      "tooltip": "Pełny ekran",
+      "trigger": "Przełącz w tryb pełnoekranowy",
+      "close": "Wyjdź z trybu pełnoekranowego"
+    },
+    "toc": {
+      "tooltip": "Spis treści",
+      "trigger": "Spis treści",
+      "close": "Zamknij spis treści",
+      "heading": "Spis treści",
+      "entries": "Pozycje w spisie treści",
+      "empty": "Spis treści nie został dostarczony dla tej publikacji.",
+      "search": {
+        "label": "Szukaj",
+        "placeholder": "Szukaj",
+        "clear": "Wyczyść"
+      }
+    },
+    "jumpToPosition": {
+      "tooltip": "Przejdź do...",
+      "trigger": "Przejdź do pozycji",
+      "heading": "Przejdź do pozycji",
+      "go": "Idź",
+      "close": "Zamknij (przejście do pozycji)",
+      "label": "Wybierz pozycję od {{ positionStart }} do {{ positionEnd }}:"
+    },
+    "overflowMenu": {
+      "active": {
+        "tooltip": "Więcej akcji",
+        "trigger": "Przełącz menu"
+      },
+      "hint": {
+        "tooltip": "Przełącz akcje",
+        "trigger": "Wyświetl akcje"
+      }
+    },
+    "layoutStrategy": {
+      "tooltip": "Układ",
+      "trigger": "Strategia układu",
+      "close": "Zamknij menu strategii układu",
+      "heading": "Strategia układu",
+      "title": "Strategia",
+      "margin": "Margines",
+      "lineLength": "Długość wersu",
+      "columns": "Kolumny",
+      "minChars": "Wyłącz minimalną długość wersu",
+      "maxChars": "Wyłącz maksymalną długość wersu",
+      "minimalLineLength": {
+        "title": "Minimalna długość wersu",
+        "increase": "Zwiększ minimalną długość wersu",
+        "decrease": "Zmniejsz minimalną długość wersu"
+      },
+      "optimalLineLength": {
+        "title": "Optymalna długość wersu",
+        "increase": "Zwiększ optymalną długość wersu",
+        "decrease": "Zmniejsz optymalną długość wersu"
+      },
+      "maximalLineLength": {
+        "title": "Maksymalna długość wersu",
+        "increase": "Zwiększ maksymalną długość wersu",
+        "decrease": "Zmniejsz maksymalną długość wersu"
+      }
+    },
+    "settings": {
+      "tooltip": "Ustawienia",
+      "trigger": "Menu ustawień",
+      "close": "Zamknij menu ustawień",
+      "heading": "Ustawienia wyświetlania",
+      "themes": {
+        "title": "Motywy",
+        "auto": "Automatyczny",
+        "light": "Jasny",
+        "sepia": "Sepia",
+        "paper": "Papier",
+        "dark": "Ciemny",
+        "contrast1": "Kontrast 1",
+        "contrast2": "Kontrast 2",
+        "contrast3": "Kontrast 3"
+      },
+      "zoom": {
+        "title": "Powiększenie",
+        "increase": "Zwiększ powiększenie",
+        "decrease": "Zmniejsz powiększenie"
+      },
+      "fontSize": {
+        "title": "Rozmiar czcionki",
+        "increase": "Zwiększ rozmiar czcionki",
+        "decrease": "Zmniejsz rozmiar czcionki"
+      },
+      "fontFamily": {
+        "title": "Wybór czcionek",
+        "labels": {
+          "publisher": "Czcionka wydawcy",
+          "oldStyle": "Old style serif",
+          "modern": "Modern serif",
+          "sans": "Sans-serif",
+          "humanist": "Humanist sans-serif",
+          "monospace": "Monospace"
+        }
+      },
+      "fontWeight": {
+        "title": "Grubość kroju",
+        "increase": "Zwiększ grubość kroju",
+        "decrease": "Zmniejsz grubość kroju"
+      },
+      "normalizeText": {
+        "title": "Normalizacja tekstu",
+        "label": "Usuń całe formatowanie tekstu"
+      },
+      "align": {
+        "title": "Wyrównanie tekstu",
+        "publisher": "Domyślne",
+        "left": "Do lewej",
+        "justify": "Wyjustuj",
+        "right": "Do prawej"
+      },
+      "hyphens": {
+        "title": "Dzielenie wyrazów",
+        "label": "Włącz dzielenie wyrazów"
+      },
+      "text": {
+        "title": "Tekst",
+        "advanced": {
+          "tooltip": "Więcej opcji",
+          "trigger": "Więcej opcji formatowania"
+        }
+      },
+      "lineHeight": {
+        "title": "Interlinia",
+        "publisher": "Domyślna",
+        "small": "Ciasna",
+        "medium": "Zrównow.",
+        "large": "Luźna"
+      },
+      "paraSpacing": {
+        "title": "Odstęp między akapitami",
+        "increase": "Zwiększ odstęp między akapitami",
+        "decrease": "Zmniejsz odstęp między akapitami"
+      },
+      "paraIndent": {
+        "title": "Wcięcie akapitu",
+        "increase": "Zwiększ wcięcie akapitu",
+        "decrease": "Zmniejsz wcięcie akapitu"
+      },
+      "wordSpacing": {
+        "title": "Odstępy między wyrazami",
+        "increase": "Zwiększ odstępy między wyrazami",
+        "decrease": "Zmniejsz odstępy między wyrazami"
+      },
+      "letterSpacing": {
+        "title": "Odstępy między literami",
+        "increase": "Zwiększ odstępy między literami",
+        "decrease": "Zmniejsz odstępy między literami"
+      },
+      "publisherStyles": {
+        "label": "Użyj oryginalnego formatowania"
+      },
+      "spacing": {
+        "title": "Odstępy",
+        "advanced": {
+          "tooltip": "Więcej opcji",
+          "trigger": "Więcej opcji odstępów"
+        }
+      },
+      "layout": {
+        "title": "Układ",
+        "scrolled": "Ciągły",
+        "paginated": "Stronicowany"
+      },
+      "column": {
+        "title": "Kolumny",
+        "auto": "Automatycznie",
+        "one": "1 kol",
+        "two": "2 kol"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Until now, there was only one locale in the project, `en`, which was hardcoded by `import Locale from "en.json"`. I have created a new context, `AppLocale`, which holds a translation hash for all components in the interface. Except for a few places, when the book is being loaded, I replaced the import to `let locale = useLocale()` and changed all the `Locale` to `locale`.

Additionally, I added the Polish translation and set the interface locale to a book language (which is the manifest) in `StatefullReader`.
