### PR TITLE
Safari bottom sheet glitch

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/edrlab/thorium-web/issues"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "private": false,
   "files": [
     "./dist"

--- a/src/components/Sheets/StatefulBottomSheet.tsx
+++ b/src/components/Sheets/StatefulBottomSheet.tsx
@@ -278,7 +278,7 @@ export const StatefulBottomSheet = ({
           action: {
             type: "focus",
             options: {
-              preventScroll: scrollTopOnFocus ? true : false,
+              preventScroll: true, // Safari needs this otherwise focus() creates artifacts on open
               scrollContainerToTop: scrollTopOnFocus
             }
           },

--- a/src/core/Components/Containers/ThBottomSheet/ThBottomSheet.tsx
+++ b/src/core/Components/Containers/ThBottomSheet/ThBottomSheet.tsx
@@ -131,10 +131,13 @@ const ThBottomSheetContainer = ({
     return [modifiedHeader, body];
   }, [children, dialog.titleProps]);
 
-  const updatedFocusOptions = focusOptions ? {
-    ...focusOptions,
-    scrollerRef: scrollerRef
-  } : undefined;
+  const updatedFocusOptions = useMemo(() => 
+    focusOptions ? {
+      ...focusOptions,
+      scrollerRef: scrollerRef
+    } : undefined,
+    [focusOptions, scrollerRef]
+  );
 
   useFirstFocusable(updatedFocusOptions);
 

--- a/src/core/Components/Containers/hooks/useFirstFocusable.ts
+++ b/src/core/Components/Containers/hooks/useFirstFocusable.ts
@@ -112,7 +112,7 @@ export const useFirstFocusable = (props?: UseFirstFocusableProps) => {
 
         switch (actionRef.current.type) {
           case "focus": {
-            const preventScroll = actionRef.current.options?.preventScroll;
+            const preventScroll = actionRef.current.options?.scrollContainerToTop || actionRef.current.options?.preventScroll;
             element.focus({ preventScroll: preventScroll ?? false });
             
             // Handle container scrolling if requested


### PR DESCRIPTION
This resolves a Glitch in Safari where a bottom sheet with no snappoint using simple detent would visibly open @ full-height of the screen then snap back to its content height. 

This seems to be tied to the `focus` issue in the bottom sheet where Safari simply shifts the sheet entirely instead of focus-scrolling scoped in the scroller element. This is the only browser doing that and all attempts through obscure CSS have failed so far. 