### PR TITLE
Urgent fixes for pagination arrows

### DIFF
--- a/docs/customization/Customization.md
+++ b/docs/customization/Customization.md
@@ -147,6 +147,9 @@ The configuration object can have the following properties:
     - `"fullscreenChange"`: Show when exiting fullscreen
     - `"layoutChange"`: Show when layout changes from scroll to paginated
 
+> [!NOTE]
+> FXL arrows `variant` is always `layered`, no matter the configuration. FXL navigator is using the window width to calculate the layout, so we need to force the layered variant to prevent layout issues at the time being.
+
 For instance:
 
 ```

--- a/docs/packages/Core/API/Components/Settings.md
+++ b/docs/packages/Core/API/Components/Settings.md
@@ -187,7 +187,7 @@ interface ThSettingsWrapperProps extends HTMLAttributesWithRef<HTMLDivElement> {
   prefs: ThSettingsPrefs;                         // Display preferences
   compounds?: {
     label?: string;                               // Advanced settings label
-    heading?: HeadingProps;                       // Props for heading
+    heading?: React.ReactElement<typeof Heading> | WithRef<HeadingProps, HTMLHeadingElement>;  // Custom heading element or props for the default Heading component
     button?: ThActionButtonProps;                 // Props for advanced settings button
   }
 }

--- a/docs/packages/Epub/API/Components.md
+++ b/docs/packages/Epub/API/Components.md
@@ -73,6 +73,7 @@ Settings components provide user configuration options:
 
 ### Base Components
 - `StatefulGroupWrapper`: Wrapper for settings groups
+- `StatefulDropdown`: Dropdown menu with selectable options
 - `StatefulNumberField`: Numeric input field
 - `StatefulRadioGroup`: Radio button group
 - `StatefulSlider`: Slider control

--- a/docs/packages/Epub/API/Settings.md
+++ b/docs/packages/Epub/API/Settings.md
@@ -10,7 +10,7 @@ A wrapper component for grouping related settings with advanced options.
 
 ```typescript
 interface StatefulGroupWrapperProps {
-  heading: string;
+  label: string;
   moreLabel: string;
   moreTooltip: string;
   onPressMore: (e: PressEvent) => void;
@@ -20,14 +20,34 @@ interface StatefulGroupWrapperProps {
     main: ThTextSettingsKeys[] | ThSpacingSettingsKeys[];
     subPanel: ThTextSettingsKeys[] | ThSpacingSettingsKeys[];
   };
+  compounds?: {
+    heading?: React.ReactElement<typeof Heading> | WithRef<HeadingProps, HTMLHeadingElement>;
+  };
 }
 ```
 
 **Features:**
 - Groups related settings components
 - Provides advanced options subpanel
+- Custom heading support
 - Manages preferences and defaults
 - Integrates with the plugin system
+
+### StatefulDropdown
+
+A dropdown menu component for selecting from predefined options.
+
+```typescript
+interface StatefulDropdownProps extends Omit<ThDropdownProps, "classNames"> {
+  standalone?: boolean;
+}
+```
+
+**Features:**
+- Dropdown menu with selectable options
+- Keyboard navigation
+- Accessibility support
+
 
 ### StatefulNumberField
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/edrlab/thorium-web/issues"
   },
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": false,
   "files": [
     "./dist"

--- a/src/components/Plugins/helpers/createDefaultPlugin.ts
+++ b/src/components/Plugins/helpers/createDefaultPlugin.ts
@@ -33,7 +33,7 @@ export const createDefaultPlugin = (): ThPlugin => {
     id: "core",
     name: "Core Components",
     description: "Default components for Thorium Web Epub StatefulReader",
-    version: "1.0.6",
+    version: "1.0.8",
     components: {
       actions: {
         [ThActionsKeys.fullscreen]: {

--- a/src/components/Settings/Spacing/StatefulSpacingGroup.tsx
+++ b/src/components/Settings/Spacing/StatefulSpacingGroup.tsx
@@ -32,7 +32,7 @@ export const StatefulSpacingGroup = () => {
   return (
     <>
     <StatefulGroupWrapper<ThSpacingSettingsKeys> 
-      heading={ t("reader.settings.spacing.title") }
+      label={ t("reader.settings.spacing.title") }
       moreLabel={ t("reader.settings.spacing.advanced.trigger") }
       moreTooltip={ t("reader.settings.spacing.advanced.tooltip") }
       onPressMore={ setSpacingContainer }

--- a/src/components/Settings/StatefulGroupWrapper.tsx
+++ b/src/components/Settings/StatefulGroupWrapper.tsx
@@ -3,18 +3,21 @@
 import readerSharedUI from "../assets/styles/readerSharedUI.module.css";
 import settingsStyles from "./assets/styles/settings.module.css";
 
+import { WithRef } from "@/core/Components/customTypes";
+
 import { ThSettingsGroupPref, ThSpacingSettingsKeys, ThTextSettingsKeys } from "@/preferences";
 import { PressEvent } from "react-aria";
+
 import { SettingComponent } from "@/components/Plugins/PluginRegistry";
 
 import { ThSettingsWrapper } from "@/core/Components/Settings/ThSettingsWrapper";
-
+import { Heading, HeadingProps } from "react-aria-components";
 import { usePreferences } from "@/preferences/hooks/usePreferences";
 
 import classNames from "classnames";
 
 export interface StatefulGroupWrapperProps<T extends string = ThTextSettingsKeys | ThSpacingSettingsKeys> {
-  heading: string;
+  label: string;
   moreLabel: string;
   moreTooltip: string;
   onPressMore: (e: PressEvent) => void;
@@ -24,16 +27,27 @@ export interface StatefulGroupWrapperProps<T extends string = ThTextSettingsKeys
     main: T[];
     subPanel: T[];
   };
+  isDisabled?: boolean;
+  compounds?: {
+    /** 
+     * Custom heading. Can be either:
+     * - A React element that will be rendered directly
+     * - Props that will be spread onto the default Heading component
+     */
+    heading?: React.ReactElement<typeof Heading> | WithRef<HeadingProps, HTMLHeadingElement>;
+  };
 }
 
 export const StatefulGroupWrapper = <T extends string = ThTextSettingsKeys | ThSpacingSettingsKeys>({
-  heading,
+  label,
   moreLabel,
   moreTooltip,
   onPressMore,
   componentsMap,
   prefs,
-  defaultPrefs
+  defaultPrefs,
+  isDisabled,
+  compounds
 }: StatefulGroupWrapperProps<T>) => {
   const { preferences } = usePreferences();
   
@@ -51,23 +65,28 @@ export const StatefulGroupWrapper = <T extends string = ThTextSettingsKeys | ThS
     <>
     <ThSettingsWrapper
       className={ classNames(settingsStyles.readerSettingsGroup, settingsStyles.readerSettingsAdvancedGroup) }
+      label={ label }
       items={ componentsMap }
       prefs={ resolvedPrefs }
       compounds={{
-        label: heading,
-        heading: {
-          className: classNames(settingsStyles.readerSettingsLabel, settingsStyles.readerSettingsGroupLabel)
-        },
-        button: {
-          className: classNames(readerSharedUI.icon, settingsStyles.readerSettingsAdvancedIcon),
-          "aria-label": moreLabel,
-          compounds: {
-            tooltipTrigger: {
-              delay: preferences.theming.icon.tooltipDelay,
-              closeDelay: preferences.theming.icon.tooltipDelay
-            },
-            tooltip: {
-              className: readerSharedUI.tooltip,
+        ...(compounds?.heading 
+          ? { heading: compounds.heading }
+          : {
+              heading: {
+                className: classNames(settingsStyles.readerSettingsLabel, settingsStyles.readerSettingsGroupLabel)
+              }
+            }),
+        button: { 
+          className: classNames(readerSharedUI.icon, settingsStyles.readerSettingsAdvancedIcon), 
+          "aria-label": moreLabel, 
+          isDisabled: isDisabled, 
+          compounds: { 
+            tooltipTrigger: { 
+              delay: preferences.theming.icon.tooltipDelay, 
+              closeDelay: preferences.theming.icon.tooltipDelay 
+            }, 
+            tooltip: { 
+              className: readerSharedUI.tooltip, 
               placement: "top",
               offset: preferences.theming.icon.tooltipOffset || 0
             },

--- a/src/components/Settings/Text/StatefulTextGroup.tsx
+++ b/src/components/Settings/Text/StatefulTextGroup.tsx
@@ -32,7 +32,7 @@ export const StatefulTextGroup = () => {
   return(
     <>
     <StatefulGroupWrapper<ThTextSettingsKeys> 
-      heading={ t("reader.settings.text.title") }
+      label={ t("reader.settings.text.title") }
       moreLabel={ t("reader.settings.text.advanced.trigger") }
       moreTooltip={ t("reader.settings.text.advanced.tooltip") }
       onPressMore={ setTextContainer }

--- a/src/core/Components/Settings/ThSettingsWrapper/ThSettingsWrapper.tsx
+++ b/src/core/Components/Settings/ThSettingsWrapper/ThSettingsWrapper.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import React from "react";
+
 import { ThSettingsWrapperButton } from "./ThSettingsWrapperButton";
 
 import { Heading, HeadingProps } from "react-aria-components";
@@ -16,17 +18,19 @@ export interface ThSettingsPrefs {
 }
 
 export interface ThSettingsWrapperProps extends HTMLAttributesWithRef<HTMLDivElement> {
+  /**
+   * Label for advanced settings that will be displayed as a heading
+   */
+  label?: string;
   items?: Record<string, ThSettingsEntry> | null;
   prefs: ThSettingsPrefs;
   compounds?: {
     /**
-     * Label for advanced settings that will be displayed as a heading
+     * Props for the heading. Can be either:
+     * - A React element that will be rendered directly
+     * - Props that will be spread onto the default Heading component
      */
-    label?: string;
-    /**
-     * Props for the heading. See `HeadingProps` for more information.
-     */
-    heading?: WithRef<HeadingProps, HTMLHeadingElement>;
+    heading?: WithRef<HeadingProps, HTMLHeadingElement> | React.ReactElement<typeof Heading>;
     /**
      * Props for the button that triggers the subpanel. See `ThActionButtonProps` for more information.
      */
@@ -37,6 +41,7 @@ export interface ThSettingsWrapperProps extends HTMLAttributesWithRef<HTMLDivEle
 // TODO: Handle Standalone and Usage as Group
 export const ThSettingsWrapper = ({
   ref,
+  label,
   items,
   prefs,
   compounds,
@@ -45,7 +50,7 @@ export const ThSettingsWrapper = ({
   const main = prefs.main;
   const displayOrder = prefs.subPanel;
   
-  const isAdvanced = items &&(
+  const isAdvanced = items && (
     main.length < Object.keys(items).length && 
     displayOrder && displayOrder.length > 0
   );
@@ -57,10 +62,14 @@ export const ThSettingsWrapper = ({
         ref={ ref }
         { ...props }
       >
-        { isAdvanced && compounds?.label &&
-          <Heading { ...compounds?.heading }>
-            { compounds.label }
-          </Heading> }
+        { isAdvanced && (compounds?.heading && React.isValidElement(compounds.heading)
+          ? compounds.heading
+          : label && (
+              <Heading { ...(compounds?.heading || {}) }>
+                { label }
+              </Heading>
+            )
+        ) }
         { main.map((key, index) => {
           const match = items[key];
           return match && <match.Comp key={ key } standalone={ !isAdvanced || index !== 0 } { ...props } />;

--- a/src/hooks/usePaginatedArrows.ts
+++ b/src/hooks/usePaginatedArrows.ts
@@ -51,14 +51,28 @@ export const usePaginatedArrows = (): UsePaginatedArrowsReturn => {
     return prefsMap[breakpoint as keyof typeof prefsMap] || prefs.default;
   }, [breakpoint, isFXL, preferences]);
 
-  // Track previous variant
+  // Track previous prefs
   const prevVariant = usePrevious(variant);
+  const prevDiscard = usePrevious(discard);
 
   // Handle state transitions
   useEffect(() => {
-    // Reset hasArrows when changing from "none" to "stacked" or "layered"
+    // If navigation was just added to discard, reset navigation state
+    if (!prevDiscard?.includes("navigation") && discard?.includes("navigation")) {
+      dispatch(setUserNavigated(false));
+      return;
+    }
+    
+    // If discard changed to "none", show the arrows and reset navigation state
+    if (discard === "none" && prevDiscard !== "none") {
+      dispatch(setHasArrows(true));
+      dispatch(setUserNavigated(false));
+      return;
+    }
+    // Reset when changing from "none" to "stacked" or "layered"
     if (prevVariant === ThArrowVariant.none && variant !== ThArrowVariant.none) {
       dispatch(setHasArrows(true));
+      dispatch(setUserNavigated(false));
       return;
     }
 
@@ -83,7 +97,7 @@ export const usePaginatedArrows = (): UsePaginatedArrowsReturn => {
     } else if (shouldShow) {
       dispatch(setHasArrows(true));
     }
-  }, [toImmersive, toFullscreen, toUserNavigation, fromImmersive, fromFullscreen, fromScroll, discard, hint, prevVariant, variant, dispatch]);
+  }, [toImmersive, toFullscreen, toUserNavigation, fromImmersive, fromFullscreen, fromScroll, discard, hint, prevVariant, variant, prevDiscard, dispatch]);
 
   // Early return for special cases
   if (variant === ThArrowVariant.none || isScroll) {

--- a/src/preferences/defaultPreferences.ts
+++ b/src/preferences/defaultPreferences.ts
@@ -338,18 +338,13 @@ export const defaultPreferences: ThPreferences<DefaultKeys> = createPreferences<
         }
       },
       fxl: {
+        // Note FXL arrows are always layered
+        // FXL navigator is using the window width to calculate the layout
+        // so we need to force the layered variant to prevent layout issues
         default: {
           variant: ThArrowVariant.layered,
           discard: ["navigation"],
           hint: "none"
-        },
-        breakpoints: {
-          [ThBreakpoints.large]: {
-            variant: ThArrowVariant.stacked
-          },
-          [ThBreakpoints.xLarge]: {
-            variant: ThArrowVariant.stacked
-          }
         }
       }
     }


### PR DESCRIPTION
This updates the hook for paginated arrows (implements missing transitions) and corrects them for FXL, and provide a way to pass arbitrary settings group headings for advanced use cases, as well as supporting the disabling of the “more options button”.