### PR TITLE
Quickfix: WebPubNavigator loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/edrlab/thorium-web/issues"
   },
-  "version": "1.1.3",
+  "version": "1.1.4",
   "private": false,
   "files": [
     "./dist"

--- a/src/components/Plugins/helpers/createDefaultPlugin.ts
+++ b/src/components/Plugins/helpers/createDefaultPlugin.ts
@@ -33,7 +33,7 @@ export const createDefaultPlugin = (): ThPlugin => {
     id: "core",
     name: "Core Components",
     description: "Default components for Thorium Web Epub StatefulReader",
-    version: "1.1.3",
+    version: "1.1.4",
     components: {
       actions: {
         [ThActionsKeys.fullscreen]: {

--- a/src/components/WebPub/StatefulReader.tsx
+++ b/src/components/WebPub/StatefulReader.tsx
@@ -482,7 +482,7 @@ const WebPubStatefulReaderInner = ({ rawManifest, selfHref }: { rawManifest: obj
       WebPubNavigatorDestroy(() => p.destroy());
       removeFontResources();
     };
-  }, [publication, preferences, isFontFamilyUsed, resolveFontLanguage, injectFontResources, removeFontResources]);
+  }, [publication, preferences, isFontFamilyUsed, injectFontResources, removeFontResources]);
 
   return (
     <>


### PR DESCRIPTION
Quickfix because the init of Navigators will be entirely rewritten with audio.