### PR TITLE
Fix: add onHover in CSS modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/edrlab/thorium-web/issues"
   },
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "files": [
     "./dist"

--- a/src/app/read/[identifier]/page.tsx
+++ b/src/app/read/[identifier]/page.tsx
@@ -57,7 +57,6 @@ export default function BookPage({ params }: Props) {
     return (
       <ErrorDisplay 
         error={ domainError }
-        title="reader.app.errors.accessDeniedTitle"
       />
     );
   }

--- a/src/app/read/manifest/[manifest]/page.tsx
+++ b/src/app/read/manifest/[manifest]/page.tsx
@@ -50,7 +50,6 @@ export default function ManifestPage({ params }: Props) {
     return (
       <ErrorDisplay 
         error={ domainError }
-        title="reader.app.errors.accessDeniedTitle"
       />
     );
   }

--- a/src/components/Actions/JumpToPosition/assets/styles/thorium-web.jumpToPosition.module.css
+++ b/src/components/Actions/JumpToPosition/assets/styles/thorium-web.jumpToPosition.module.css
@@ -30,6 +30,7 @@
 
 .button[data-hovered] {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .input[data-focus-visible],

--- a/src/components/Actions/Toc/assets/styles/thorium-web.toc.module.css
+++ b/src/components/Actions/Toc/assets/styles/thorium-web.toc.module.css
@@ -120,6 +120,7 @@
 /* [data-hover] is only updated on tree items that can be expanded ATM… */
 .treeItem:hover {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .treeItem[data-focus-visible] {

--- a/src/components/Actions/assets/styles/thorium-web.overflow.module.css
+++ b/src/components/Actions/assets/styles/thorium-web.overflow.module.css
@@ -37,6 +37,7 @@
 
 .menuItem[data-hovered] {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .menuItem[data-focus-visible] {

--- a/src/components/Settings/assets/styles/thorium-web.reader.settings.module.css
+++ b/src/components/Settings/assets/styles/thorium-web.reader.settings.module.css
@@ -143,6 +143,7 @@
 
 .radio[data-hovered] {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .radio[data-focus-visible] {

--- a/src/components/assets/styles/thorium-web.backlink.module.css
+++ b/src/components/assets/styles/thorium-web.backlink.module.css
@@ -21,6 +21,7 @@
 
 .link[data-hovered] {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .link[data-focus-visible] {

--- a/src/components/assets/styles/thorium-web.button.module.css
+++ b/src/components/assets/styles/thorium-web.button.module.css
@@ -36,6 +36,7 @@
 .closeButton[data-hovered],
 .backButton[data-hovered] {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .icon[data-focus-visible],

--- a/src/components/assets/styles/thorium-web.reader.pagination.module.css
+++ b/src/components/assets/styles/thorium-web.reader.pagination.module.css
@@ -49,6 +49,7 @@
 
 .listItem button[data-hovered] {
   background-color: var(--th-theme-hover);
+  color: var(--th-theme-onHover);
 }
 
 .listItem button[data-focus-visible] {


### PR DESCRIPTION
Resolves #186 by adding `th-theme-onHover` in selectors where `th-theme-hover` is used. 