### PR TITLE
Disable audiobook volume for iOS

### DIFF
--- a/src/components/Audio/actions/Volume/StatefulAudioVolumeContainer.tsx
+++ b/src/components/Audio/actions/Volume/StatefulAudioVolumeContainer.tsx
@@ -19,6 +19,8 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { setVolume } from "@/lib/audioSettingsReducer";
 import { setActionOpen } from "@/lib/actionsReducer";
 
+import { isIOSish } from "@/core/Helpers/getPlatform";
+
 export const StatefulAudioVolumeContainer = ({ triggerRef, placement = "top" }: StatefulActionContainerProps) => {
   const volume = useAppSelector(state => state.audioSettings.volume);
   const profile = useAppSelector(state => state.reader.profile);
@@ -51,6 +53,8 @@ export const StatefulAudioVolumeContainer = ({ triggerRef, placement = "top" }: 
       dispatch(setActionOpen({ key: ThAudioActionKeys.volume, isOpen: open, profile }));
     }
   }, [dispatch, profile]);
+
+  if (isIOSish()) return null;
 
   return (
     <StatefulSheetWrapper

--- a/src/components/Audio/actions/Volume/StatefulAudioVolumeTrigger.tsx
+++ b/src/components/Audio/actions/Volume/StatefulAudioVolumeTrigger.tsx
@@ -21,6 +21,8 @@ import { useAppDispatch, useAppSelector } from "@/lib/hooks";
 import { toggleActionOpen } from "@/lib/actionsReducer";
 import { useNavigator } from "@/core/Navigator";
 
+import { isIOSish } from "@/core/Helpers/getPlatform";
+
 export const StatefulAudioVolumeTrigger = ({ ref }: StatefulActionTriggerProps) => {
   const { t } = useI18n();
   const profile = useAppSelector(state => state.reader.profile);
@@ -44,6 +46,8 @@ export const StatefulAudioVolumeTrigger = ({ ref }: StatefulActionTriggerProps) 
     if (volume <= (max / 3) * 2) return VolumeDownIcon;
     return VolumeUpIcon;
   }, [volume, range]);
+
+  if (isIOSish()) return null;
 
   return (
     <StatefulActionIcon

--- a/src/core/Helpers/getPlatform.ts
+++ b/src/core/Helpers/getPlatform.ts
@@ -46,7 +46,7 @@ export const isIpadOS = () => {
         && navigator.userAgent.includes("Intel"));
 }
 
-// Stopgap measure for fullscreen on iPadOS, do not use elsewhere
+// Covers all iOS/iPadOS: iPhone/iPod/iPad by platform string + desktop-class iPadOS by UA sniff
 export const isIOSish = () => {
   const AppleMobilePattern = /ipod|iphone|ipad/i;
   const platform = getPlatform();


### PR DESCRIPTION
This returns `null` for volume action in audiobooks on iOS since the value is readable and settable but is always `1`. 

This is achieved in a similar fashion as `fullscreen` action. 

See [MDN > Browser Compatibility > iOS](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/volume#browser_compatibility)