### PR TITLE
I18n data

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "increment": "node scripts/increment.mjs"
   },
   "peerDependencies": {
-    "@readium/css": "^2.0.3",
+    "@readium/css": "^2.0.4",
     "@readium/navigator": "^2.5.1",
     "@readium/navigator-html-injectables": "^2.4.1",
     "@readium/shared": "^2.2.0",
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@edrlab/thorium-locales": "github:edrlab/thorium-locales",
-    "@readium/css": "^2.0.3",
+    "@readium/css": "^2.0.4",
     "@readium/navigator": "^2.5.1",
     "@readium/navigator-html-injectables": "^2.4.1",
     "@readium/shared": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
   },
   "peerDependencies": {
     "@readium/css": "^2.0.4",
-    "@readium/navigator": "^2.5.1",
-    "@readium/navigator-html-injectables": "^2.4.1",
+    "@readium/navigator": "^2.5.2",
+    "@readium/navigator-html-injectables": "^2.4.2",
     "@readium/shared": "^2.2.0",
     "@reduxjs/toolkit": "^2.11.2",
     "i18next": "^25.8.13",
@@ -86,8 +86,8 @@
   "dependencies": {
     "@edrlab/thorium-locales": "github:edrlab/thorium-locales",
     "@readium/css": "^2.0.4",
-    "@readium/navigator": "^2.5.1",
-    "@readium/navigator-html-injectables": "^2.4.1",
+    "@readium/navigator": "^2.5.2",
+    "@readium/navigator-html-injectables": "^2.4.2",
     "@readium/shared": "^2.2.0",
     "@reduxjs/toolkit": "^2.11.2",
     "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "increment": "node scripts/increment.mjs"
   },
   "peerDependencies": {
-    "@readium/css": "^2.0.2",
+    "@readium/css": "^2.0.3",
     "@readium/navigator": "^2.5.1",
     "@readium/navigator-html-injectables": "^2.4.1",
     "@readium/shared": "^2.2.0",
@@ -85,7 +85,7 @@
   },
   "dependencies": {
     "@edrlab/thorium-locales": "github:edrlab/thorium-locales",
-    "@readium/css": "^2.0.2",
+    "@readium/css": "^2.0.3",
     "@readium/navigator": "^2.5.1",
     "@readium/navigator-html-injectables": "^2.4.1",
     "@readium/shared": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: github:edrlab/thorium-locales
         version: thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/4a9e7d687d9469ffd1c9fa153cb2b7fc93b15cb8
       '@readium/css':
-        specifier: ^2.0.3
-        version: 2.0.3
+        specifier: ^2.0.4
+        version: 2.0.4
       '@readium/navigator':
         specifier: ^2.5.1
         version: 2.5.1
@@ -1830,8 +1830,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@readium/css@2.0.3':
-    resolution: {integrity: sha512-nCMjussYo3Y4lAVHuRtf+dCHC5Bmqy32rJBr5Dllp1hsSsZQ4RAiOdx2nzH6iTRpfnINp0aevHSD8tpSFPHElg==}
+  '@readium/css@2.0.4':
+    resolution: {integrity: sha512-+WQoL7/GG0VECHtGd+XZlC5JyLBG6DiPEKDTz9QGg9CVaA7bZ0fcAVNB86MDHP+RGQ/DWDIuiw1stzpapylnrA==}
 
   '@readium/navigator-html-injectables@2.4.1':
     resolution: {integrity: sha512-Yt5xmwvBWMXX+GMvfYaFgMwFjvYiWAKHWYYNmpVw3IMGYcfAC04SGavA4Evu5oNrqAgb0ImseDGNrofq+/9NGQ==}
@@ -6304,7 +6304,7 @@ snapshots:
       '@react-types/shared': 3.33.0(react@19.2.4)
       react: 19.2.4
 
-  '@readium/css@2.0.3': {}
+  '@readium/css@2.0.4': {}
 
   '@readium/navigator-html-injectables@2.4.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: github:edrlab/thorium-locales
         version: thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/4a9e7d687d9469ffd1c9fa153cb2b7fc93b15cb8
       '@readium/css':
-        specifier: ^2.0.2
-        version: 2.0.2
+        specifier: ^2.0.3
+        version: 2.0.3
       '@readium/navigator':
         specifier: ^2.5.1
         version: 2.5.1
@@ -1830,8 +1830,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  '@readium/css@2.0.2':
-    resolution: {integrity: sha512-2cLkU3NPzLlVxVWPlyxoFTCFE2y5521cQ+sgHnPBAKnOdCh3SltQwd7XodvB+xTGgS4TdVbQmxfr3x1Ke6nZWA==}
+  '@readium/css@2.0.3':
+    resolution: {integrity: sha512-nCMjussYo3Y4lAVHuRtf+dCHC5Bmqy32rJBr5Dllp1hsSsZQ4RAiOdx2nzH6iTRpfnINp0aevHSD8tpSFPHElg==}
 
   '@readium/navigator-html-injectables@2.4.1':
     resolution: {integrity: sha512-Yt5xmwvBWMXX+GMvfYaFgMwFjvYiWAKHWYYNmpVw3IMGYcfAC04SGavA4Evu5oNrqAgb0ImseDGNrofq+/9NGQ==}
@@ -6304,7 +6304,7 @@ snapshots:
       '@react-types/shared': 3.33.0(react@19.2.4)
       react: 19.2.4
 
-  '@readium/css@2.0.2': {}
+  '@readium/css@2.0.3': {}
 
   '@readium/navigator-html-injectables@2.4.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4
       '@readium/navigator':
-        specifier: ^2.5.1
-        version: 2.5.1
+        specifier: ^2.5.2
+        version: 2.5.2
       '@readium/navigator-html-injectables':
-        specifier: ^2.4.1
-        version: 2.4.1
+        specifier: ^2.4.2
+        version: 2.4.2
       '@readium/shared':
         specifier: ^2.2.0
         version: 2.2.0
@@ -1833,12 +1833,12 @@ packages:
   '@readium/css@2.0.4':
     resolution: {integrity: sha512-+WQoL7/GG0VECHtGd+XZlC5JyLBG6DiPEKDTz9QGg9CVaA7bZ0fcAVNB86MDHP+RGQ/DWDIuiw1stzpapylnrA==}
 
-  '@readium/navigator-html-injectables@2.4.1':
-    resolution: {integrity: sha512-Yt5xmwvBWMXX+GMvfYaFgMwFjvYiWAKHWYYNmpVw3IMGYcfAC04SGavA4Evu5oNrqAgb0ImseDGNrofq+/9NGQ==}
+  '@readium/navigator-html-injectables@2.4.2':
+    resolution: {integrity: sha512-C08vjzYek19VU9JnCvhTorO8xVsR8hcCzSCD0IondBYOtcRbBzu18Ezp3WQR47/a/9tQMGicOS9knmmll1fZuw==}
     engines: {node: '>=18'}
 
-  '@readium/navigator@2.5.1':
-    resolution: {integrity: sha512-GlQiFT/iJpuu2dLOKG+vcSxmmA9QmqvOAy6M2R8tgp0dXwLafa6guw+J9Jm9dAIyID5HzJzZ9FM2hV77GCFlyQ==}
+  '@readium/navigator@2.5.2':
+    resolution: {integrity: sha512-npSbb9HQSUOlaGjxRbSgGPSPOTJRljwSWg3ZWlg0BQ6T+gp3qxAJ461eXPVwpEpVWERe33Kih/o8KcmNlqYl/A==}
     engines: {node: '>=18'}
 
   '@readium/shared@2.2.0':
@@ -6306,9 +6306,9 @@ snapshots:
 
   '@readium/css@2.0.4': {}
 
-  '@readium/navigator-html-injectables@2.4.1': {}
+  '@readium/navigator-html-injectables@2.4.2': {}
 
-  '@readium/navigator@2.5.1': {}
+  '@readium/navigator@2.5.2': {}
 
   '@readium/shared@2.2.0':
     dependencies:

--- a/src/components/Epub/Hooks/usePreferencesConfig.ts
+++ b/src/components/Epub/Hooks/usePreferencesConfig.ts
@@ -9,6 +9,7 @@ import { FontMetadata } from "@/preferences/services/fonts";
 import { ThColorScheme } from "@/core/Hooks/useColorScheme";
 import { ReadiumCSSSettings } from "@/core/Hooks/Epub/useEpubSettingsCache";
 import { useSettingsComponentStatus } from "@/components/Settings/hooks/useSettingsComponentStatus";
+import { useLineHeight } from "@/components/Settings/Spacing/hooks/useLineHeight";
 
 import { useAppSelector } from "@/lib/hooks";
 
@@ -23,7 +24,6 @@ interface UseEpubPreferencesConfigProps {
   arrowsWidth: React.RefObject<number>;
   preferences: ThPreferences;
   getFontMetadata: (fontFamily: string) => FontMetadata;
-  lineHeightOptions: Record<ThLineHeightOptions, number | null>;
   fxlThemeKeys: string[];
   reflowThemeKeys: string[];
 }
@@ -37,10 +37,10 @@ export const useEpubPreferencesConfig = ({
   arrowsWidth,
   preferences,
   getFontMetadata,
-  lineHeightOptions,
   fxlThemeKeys,
   reflowThemeKeys,
 }: UseEpubPreferencesConfigProps) => {
+  const { processedValues: lineHeightOptions } = useLineHeight();
   const scriptMode = useAppSelector(state => state.publication.scriptMode);
   const isVerticalScript = scriptMode === "cjk-vertical" || scriptMode === "mongolian-vertical";
 
@@ -145,7 +145,7 @@ export const useEpubPreferencesConfig = ({
         ? undefined
         : settings.lineHeight === null
           ? null
-          : lineHeightOptions[settings.lineHeight],
+          : lineHeightOptions[settings.lineHeight as ThLineHeightOptions.small | ThLineHeightOptions.medium | ThLineHeightOptions.large],
       optimalLineLength: settings.lineLength?.optimal != null
         ? settings.lineLength.optimal
         : undefined,
@@ -178,7 +178,6 @@ export const useEpubPreferencesConfig = ({
     preferences.theming.themes.keys,
     preferences.theming.themes.systemThemes,
     getFontMetadata,
-    lineHeightOptions,
     fxlThemeKeys,
     reflowThemeKeys,
     isVerticalScript,
@@ -197,6 +196,7 @@ export const useEpubPreferencesConfig = ({
     isTextAlignUsed,
     isTextNormalizeUsed,
     isWordSpacingUsed,
+    lineHeightOptions
   ]);
 
   const epubDefaults = useMemo(() => {

--- a/src/components/Epub/Hooks/useReaderInit.ts
+++ b/src/components/Epub/Hooks/useReaderInit.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 
 import { Locator, Publication } from "@readium/shared";
-import { ThLineHeightOptions } from "@/preferences/models";
 import { EpubNavigatorListeners, IContentProtectionConfig, ILinkInjectable, IBlobInjectable } from "@readium/navigator";
 import { ThPreferences } from "@/preferences";
 import { FontMetadata, InjectableFontResources } from "@/preferences/services/fonts";
@@ -30,7 +29,6 @@ interface UseEpubReaderInitProps {
   getFontInjectables: (options?: { language?: string } | { key?: string }, optimize?: boolean) => InjectableFontResources | null;
   fxlThemeKeys: string[];
   reflowThemeKeys: string[];
-  lineHeightOptions: Record<ThLineHeightOptions, number | null>;
   arrowsOccupySpace: boolean;
   arrowsWidth: React.RefObject<number>;
   colorScheme: any;
@@ -59,7 +57,6 @@ export const useEpubReaderInit = ({
   getFontInjectables,
   fxlThemeKeys,
   reflowThemeKeys,
-  lineHeightOptions,
   arrowsOccupySpace,
   arrowsWidth,
   colorScheme,
@@ -81,7 +78,6 @@ export const useEpubReaderInit = ({
     arrowsWidth,
     preferences,
     getFontMetadata,
-    lineHeightOptions,
     fxlThemeKeys,
     reflowThemeKeys,
   });

--- a/src/components/Epub/StatefulReader.tsx
+++ b/src/components/Epub/StatefulReader.tsx
@@ -62,7 +62,6 @@ import { useTimeline } from "@/core/Hooks/useTimeline";
 import { useIsScroll, usePositionStorage } from "@/hooks";
 import { useDocumentTitle } from "@/core/Hooks/useDocumentTitle";
 import { useSpacingPresets } from "../Settings/Spacing/hooks/useSpacingPresets";
-import { useLineHeight } from "../Settings/Spacing/hooks/useLineHeight";
 import { usePaginatedArrows } from "@/hooks/usePaginatedArrows";
 import { useFonts } from "@/core/Hooks/fonts/useFonts";
 
@@ -264,8 +263,6 @@ const StatefulReaderInner = ({ publication, localDataKey, positionStorage, conta
       dispatch(setTimeline(timeline));
     }
   });
-
-  const lineHeightOptions = useLineHeight();
 
   const documentTitleFormat = preferences.metadata?.documentTitle?.format;
   
@@ -550,7 +547,6 @@ const StatefulReaderInner = ({ publication, localDataKey, positionStorage, conta
     getFontInjectables,
     fxlThemeKeys,
     reflowThemeKeys,
-    lineHeightOptions,
     arrowsOccupySpace,
     arrowsWidth,
     colorScheme,

--- a/src/components/Settings/Spacing/StatefulLineHeight.tsx
+++ b/src/components/Settings/Spacing/StatefulLineHeight.tsx
@@ -15,15 +15,14 @@ import LargeIcon from "./assets/icons/density_large.svg";
 import { StatefulRadioGroup } from "../StatefulRadioGroup";
 
 import { useNavigator } from "@/core/Navigator";
-import { EpubPreferencesEditor } from "@readium/navigator";
 import { useI18n } from "@/i18n/useI18n";
 import { usePreferences } from "@/preferences/hooks/usePreferences";
-import { useEffectiveRange } from "../hooks/useEffectiveRange";
 
 import { useAppSelector } from "@/lib/hooks";
 import { useLineHeight } from "./hooks/useLineHeight";
 import { useSpacingPresets } from "./hooks/useSpacingPresets";
 import { useReaderSetting } from "../hooks/useReaderSetting";
+
 
 export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemProps) => {
   const { t } = useI18n();
@@ -34,7 +33,7 @@ export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemPr
 
   const publisherStyles = useReaderSetting("publisherStyles");
 
-  const { getSetting, submitPreferences, preferencesEditor } = useNavigator().visual;
+  const { getSetting, submitPreferences } = useNavigator().visual;
 
   const prefKey = SETTINGS_KEY_TO_PREFERENCE[ThSettingsKeys.lineHeight];
 
@@ -42,20 +41,17 @@ export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemPr
 
   const lineHeight = getEffectiveSpacingValue(ThSpacingSettingsKeys.lineHeight);
 
-  const lineHeightOptions = useLineHeight();
+  const { processedValues } = useLineHeight();
 
-  const lineHeightNumericValues = useMemo(
-    () => Object.values(lineHeightOptions).filter((v): v is number => v !== null),
-    [lineHeightOptions]
-  );
+  // Build map from processed values for settings UI
+  const processedPresets = useMemo(() => {
+    const result = new Map<ThLineHeightOptions, number>();
+    result.set(ThLineHeightOptions.small, processedValues[ThLineHeightOptions.small]);
+    result.set(ThLineHeightOptions.medium, processedValues[ThLineHeightOptions.medium]);
+    result.set(ThLineHeightOptions.large, processedValues[ThLineHeightOptions.large]);
+    return result;
+  }, [processedValues]);
 
-  const { presets: effectivePresets } = useEffectiveRange(
-    [Math.min(...lineHeightNumericValues), Math.max(...lineHeightNumericValues)],
-    (preferencesEditor as EpubPreferencesEditor | undefined)?.lineHeight?.supportedRange,
-    lineHeightNumericValues
-  );
-
-  // Dynamically build items array based on allowUnset preference and navigator supported range
   const items = useMemo(() => {
     const baseItems = [
       {
@@ -76,12 +72,8 @@ export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemPr
         label: t("reader.preferences.lineHeight.large"),
         value: ThLineHeightOptions.large
       },
-    ].filter(item => {
-      const v = lineHeightOptions[item.id];
-      return effectivePresets === undefined || effectivePresets.includes(v);
-    });
+    ].filter(item => processedPresets.has(item.id));
 
-    // Only add publisher option if allowUnset is true
     if (preferences.settings.keys[ThSettingsKeys.lineHeight].allowUnset !== false) {
       baseItems.unshift({
         id: ThLineHeightOptions.publisher,
@@ -92,21 +84,21 @@ export const StatefulLineHeight = ({ standalone = true }: StatefulSettingsItemPr
     }
 
     return baseItems;
-  }, [preferences.settings.keys, lineHeightOptions, effectivePresets, t]);
+  }, [preferences.settings.keys, processedPresets, t]);
 
   const updatePreference = useCallback(async (value: string) => {
-    const computedValue = value === ThLineHeightOptions.publisher
+    const submitValue = value === ThLineHeightOptions.publisher
       ? null
-      : lineHeightOptions[value as keyof typeof ThLineHeightOptions];
+      : processedPresets.get(value as ThLineHeightOptions) ?? null;
     await submitPreferences({
-      [prefKey]: computedValue
+      [prefKey]: submitValue
     });
 
-    const currentLineHeight = getSetting(prefKey);
-    const currentDisplayLineHeightOption = Object.entries(lineHeightOptions).find(([_key, value]) => value === currentLineHeight)?.[0] as ThLineHeightOptions;
+    const storedLineHeight = getSetting(prefKey) as number | null;
+    const currentDisplayLineHeightOption = [...processedPresets.entries()].find(([, v]) => v === storedLineHeight)?.[0] as ThLineHeightOptions;
 
     setLineHeight(currentDisplayLineHeightOption);
-  }, [prefKey, submitPreferences, getSetting, setLineHeight, lineHeightOptions]);
+  }, [prefKey, submitPreferences, getSetting, setLineHeight, processedPresets]);
 
   return (
     <>

--- a/src/components/Settings/Spacing/StatefulSpacingPresets.tsx
+++ b/src/components/Settings/Spacing/StatefulSpacingPresets.tsx
@@ -62,7 +62,7 @@ export const StatefulSpacingPresets = ({ standalone }: StatefulSettingsItemProps
   const paragraphSpacingPrefKey = SETTINGS_KEY_TO_PREFERENCE[ThSettingsKeys.paragraphSpacing];
   const wordSpacingPrefKey = SETTINGS_KEY_TO_PREFERENCE[ThSettingsKeys.wordSpacing];
 
-  const lineHeightOptions = useLineHeight();
+  const { values: lineHeightOptions, compensate: compensateLineHeight } = useLineHeight();
 
   const { getPresetValues } = useSpacingPresets();
 
@@ -104,10 +104,10 @@ export const StatefulSpacingPresets = ({ standalone }: StatefulSettingsItemProps
       [ThSpacingSettingsKeys.wordSpacing]: presetValues?.[ThSpacingSettingsKeys.wordSpacing] ?? null,
     };
   
-    // Convert lineHeight for preferences API (enum to number)
+    // Convert lineHeight for preferences API (enum to compensated number)
     const lineHeightValue = reduxValues[ThSpacingSettingsKeys.lineHeight];
     const lineHeightValueNumber = lineHeightValue && lineHeightValue !== ThLineHeightOptions.publisher
-      ? lineHeightOptions[lineHeightValue as ThLineHeightOptions]
+      ? compensateLineHeight(lineHeightOptions[lineHeightValue as ThLineHeightOptions])
       : null;
 
     // Only include spacing settings if their plugins are being used
@@ -141,7 +141,7 @@ export const StatefulSpacingPresets = ({ standalone }: StatefulSettingsItemProps
         values: reduxValues,
       }));
     }
-  }, [isWebPub, dispatch, submitPreferences, getPresetValues, lineHeightOptions, letterSpacingPrefKey, lineHeightPrefKey, paragraphIndentPrefKey, paragraphSpacingPrefKey, wordSpacingPrefKey, isLetterSpacingUsed, isLineHeightUsed, isParagraphIndentUsed, isParagraphSpacingUsed, isWordSpacingUsed]);
+  }, [isWebPub, dispatch, submitPreferences, getPresetValues, lineHeightOptions, compensateLineHeight, letterSpacingPrefKey, lineHeightPrefKey, paragraphIndentPrefKey, paragraphSpacingPrefKey, wordSpacingPrefKey, isLetterSpacingUsed, isLineHeightUsed, isParagraphIndentUsed, isParagraphSpacingUsed, isWordSpacingUsed]);
 
   // Use appropriate spacing keys based on layout
   const spacingKeys = useMemo(() => {

--- a/src/components/Settings/Spacing/hooks/useLineHeight.ts
+++ b/src/components/Settings/Spacing/hooks/useLineHeight.ts
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { ThLineHeightOptions, ThSettingsKeys } from "@/preferences/models";
 import { usePreferences } from "@/preferences/hooks/usePreferences";
 import { useAppSelector } from "@/lib/hooks";
-import { lineHeightRangeConfig } from "@readium/navigator";
+import { lineHeightRangeConfig, RCSSI18nEntry } from "@readium/navigator";
 import i18nData from "@readium/css/css/vars/i18n.json";
 
 export const ORDERED_LINE_HEIGHT_OPTIONS = [ThLineHeightOptions.small, ThLineHeightOptions.medium, ThLineHeightOptions.large] as const;
@@ -22,10 +22,8 @@ function spreadValues(values: number[], globalMin: number, globalMax: number): n
   return result;
 }
 
-type I18nEntry = { baseFontFamily?: string; lineHeightCompensation?: number };
-
 const getLineHeightCompensation = (language: string): number => {
-  const data = i18nData as Record<string, I18nEntry>;
+  const data = i18nData as Record<string, RCSSI18nEntry>;
   if (data[language]?.lineHeightCompensation !== undefined) return data[language].lineHeightCompensation!;
   const stripped = language.split("-").slice(0, -1).join("-");
   if (stripped && data[stripped]?.lineHeightCompensation !== undefined) return data[stripped].lineHeightCompensation!;

--- a/src/components/Settings/Spacing/hooks/useLineHeight.ts
+++ b/src/components/Settings/Spacing/hooks/useLineHeight.ts
@@ -1,18 +1,70 @@
 import { useMemo } from "react";
 import { ThLineHeightOptions, ThSettingsKeys } from "@/preferences/models";
 import { usePreferences } from "@/preferences/hooks/usePreferences";
+import { useAppSelector } from "@/lib/hooks";
+import { lineHeightRangeConfig } from "@readium/navigator";
+import i18nData from "@readium/css/css/vars/i18n.json";
 
-/**
- * Hook that returns a mapping of line height options to their actual numeric values
- * This eliminates code duplication across spacing components
- */
+export const ORDERED_LINE_HEIGHT_OPTIONS = [ThLineHeightOptions.small, ThLineHeightOptions.medium, ThLineHeightOptions.large] as const;
+
+// Resolves duplicate clamped values by distributing them evenly within their
+// effective range [min(clamped), max(clamped)]. Returns input unchanged if all distinct.
+function spreadValues(values: number[], globalMin: number, globalMax: number): number[] {
+  const n = values.length;
+  if (n <= 1) return values;
+  const indexed = values.map((v, i) => ({ v, i })).sort((a, b) => a.v - b.v);
+  if (indexed.every((item, i) => i === 0 || item.v !== indexed[i - 1].v)) return values;
+  const lo = indexed[0].v === indexed[n - 1].v ? globalMin : indexed[0].v;
+  const hi = indexed[0].v === indexed[n - 1].v ? globalMax : indexed[n - 1].v;
+  const step = (hi - lo) / (n - 1);
+  const result = new Array<number>(n);
+  for (let i = 0; i < n; i++) result[indexed[i].i] = lo + i * step;
+  return result;
+}
+
+type I18nEntry = { baseFontFamily?: string; lineHeightCompensation?: number };
+
+const getLineHeightCompensation = (language: string): number => {
+  const data = i18nData as Record<string, I18nEntry>;
+  if (data[language]?.lineHeightCompensation !== undefined) return data[language].lineHeightCompensation!;
+  const stripped = language.split("-").slice(0, -1).join("-");
+  if (stripped && data[stripped]?.lineHeightCompensation !== undefined) return data[stripped].lineHeightCompensation!;
+  return data.default?.lineHeightCompensation ?? 1;
+};
+
 export const useLineHeight = () => {
   const { preferences } = usePreferences();
+  const fontLanguage = useAppSelector(state => state.publication.fontLanguage);
 
-  return useMemo(() => ({
-    [ThLineHeightOptions.publisher]: null,
-    [ThLineHeightOptions.small]: preferences.settings.keys[ThSettingsKeys.lineHeight].keys[ThLineHeightOptions.small],
-    [ThLineHeightOptions.medium]: preferences.settings.keys[ThSettingsKeys.lineHeight].keys[ThLineHeightOptions.medium],
-    [ThLineHeightOptions.large]: preferences.settings.keys[ThSettingsKeys.lineHeight].keys[ThLineHeightOptions.large],
-  }), [preferences.settings.keys]);
+  return useMemo(() => {
+    const keys = preferences.settings.keys[ThSettingsKeys.lineHeight].keys;
+    const factor = getLineHeightCompensation(fontLanguage);
+    const values = {
+      [ThLineHeightOptions.publisher]: null as null,
+      [ThLineHeightOptions.small]: keys[ThLineHeightOptions.small],
+      [ThLineHeightOptions.medium]: keys[ThLineHeightOptions.medium],
+      [ThLineHeightOptions.large]: keys[ThLineHeightOptions.large],
+    };
+    const compensate = (v: number | null): number | null => v !== null ? v * factor : null;
+    const compensatedValues = {
+      [ThLineHeightOptions.publisher]: null as null,
+      [ThLineHeightOptions.small]: compensate(values[ThLineHeightOptions.small]),
+      [ThLineHeightOptions.medium]: compensate(values[ThLineHeightOptions.medium]),
+      [ThLineHeightOptions.large]: compensate(values[ThLineHeightOptions.large]),
+    };
+
+    const [minRange, maxRange] = lineHeightRangeConfig.range;
+    const clamp = (v: number | null): number =>
+      v === null ? minRange : Math.min(Math.max(v, minRange), maxRange);
+
+    const ordered = ORDERED_LINE_HEIGHT_OPTIONS;
+    const clamped = ordered.map(key => clamp(compensatedValues[key]));
+    const processed = spreadValues(clamped, minRange, maxRange);
+
+    const processedValues = Object.fromEntries(
+      ordered.map((key, i) => [key, processed[i]])
+    ) as Record<typeof ordered[number], number>;
+
+    return { values, compensatedValues, processedValues, compensate };
+  }, [preferences.settings.keys, fontLanguage]);
 };

--- a/src/components/Settings/StatefulPublisherStyles.tsx
+++ b/src/components/Settings/StatefulPublisherStyles.tsx
@@ -51,7 +51,7 @@ export const StatefulPublisherStyles = ({ standalone = true }: StatefulSettingsI
   const letterSpacing = getEffectiveSpacingValue(ThSpacingSettingsKeys.letterSpacing);
   const wordSpacing = getEffectiveSpacingValue(ThSpacingSettingsKeys.wordSpacing);
 
-  const lineHeightOptions = useLineHeight();
+  const { compensatedValues: lineHeightOptions } = useLineHeight();
 
   const { submitPreferences } = useNavigator().visual;
 

--- a/src/components/WebPub/Hooks/usePreferencesConfig.ts
+++ b/src/components/WebPub/Hooks/usePreferencesConfig.ts
@@ -7,13 +7,13 @@ import { ThLineHeightOptions, ThSettingsKeys } from "@/preferences/models";
 import { FontMetadata } from "@/preferences/services/fonts";
 import { WebPubCSSSettings } from "@/core/Hooks/WebPub/useWebPubSettingsCache";
 import { useSettingsComponentStatus } from "@/components/Settings/hooks/useSettingsComponentStatus";
+import { useLineHeight } from "@/components/Settings/Spacing/hooks/useLineHeight";
 
 interface UseWebPubPreferencesConfigProps {
   settings: WebPubCSSSettings;
   fontLanguage: string;
   hasDisplayTransformability: boolean;
   getFontMetadata: (fontFamily: string) => FontMetadata;
-  lineHeightOptions: Record<ThLineHeightOptions, number | null>;
 }
 
 export const useWebPubPreferencesConfig = ({
@@ -21,8 +21,8 @@ export const useWebPubPreferencesConfig = ({
   fontLanguage,
   hasDisplayTransformability,
   getFontMetadata,
-  lineHeightOptions,
 }: UseWebPubPreferencesConfigProps) => {
+  const { processedValues: lineHeightOptions } = useLineHeight();
   const { isComponentUsed: isFontFamilyUsed } = useSettingsComponentStatus({
     settingsKey: ThSettingsKeys.fontFamily,
     publicationType: "webpub",
@@ -96,7 +96,7 @@ export const useWebPubPreferencesConfig = ({
       if (isLetterSpacingUsed) preferences.letterSpacing = settings.letterSpacing;
       if (isLineHeightUsed) preferences.lineHeight = settings.lineHeight === null
         ? null
-        : lineHeightOptions[settings.lineHeight];
+        : lineHeightOptions[settings.lineHeight as ThLineHeightOptions.small | ThLineHeightOptions.medium | ThLineHeightOptions.large];
       if (isParagraphIndentUsed) preferences.paragraphIndent = settings.paragraphIndent;
       if (isParagraphSpacingUsed) preferences.paragraphSpacing = settings.paragraphSpacing;
       if (isTextAlignUsed) preferences.textAlign = settings.textAlign as TextAlignment | null | undefined;
@@ -111,7 +111,6 @@ export const useWebPubPreferencesConfig = ({
     fontLanguage,
     hasDisplayTransformability,
     getFontMetadata,
-    lineHeightOptions,
     isFontFamilyUsed,
     isFontWeightUsed,
     isHyphensUsed,
@@ -124,6 +123,7 @@ export const useWebPubPreferencesConfig = ({
     isTextAlignUsed,
     isTextNormalizeUsed,
     isWordSpacingUsed,
+    lineHeightOptions
   ]);
 
   return { webPubPreferences };

--- a/src/components/WebPub/Hooks/useReaderInit.ts
+++ b/src/components/WebPub/Hooks/useReaderInit.ts
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 
 import { Locator, Publication } from "@readium/shared";
-import { ThLineHeightOptions } from "@/preferences/models";
 import { WebPubNavigatorListeners, IContentProtectionConfig } from "@readium/navigator";
 import { ThPreferences } from "@/preferences";
 import { FontMetadata, InjectableFontResources } from "@/preferences/services/fonts";
@@ -27,7 +26,6 @@ interface UseWebPubReaderInitProps {
   injectFontResources: (resources: InjectableFontResources | null) => void;
   removeFontResources: () => void;
   getFontInjectables: (options?: { language?: string } | { key?: string }, optimize?: boolean) => InjectableFontResources | null;
-  lineHeightOptions: Record<ThLineHeightOptions, number | null>;
   contentProtectionConfig?: IContentProtectionConfig;
   onNavigatorReady?: () => void;
   onNavigatorLoaded?: () => void;
@@ -48,7 +46,6 @@ export const useWebPubReaderInit = ({
   injectFontResources,
   removeFontResources,
   getFontInjectables,
-  lineHeightOptions,
   contentProtectionConfig,
   onNavigatorReady,
   onNavigatorLoaded,
@@ -61,7 +58,6 @@ export const useWebPubReaderInit = ({
     fontLanguage,
     hasDisplayTransformability,
     getFontMetadata,
-    lineHeightOptions,
   });
 
   const { injectables } = useWebPubInjectablesConfig({

--- a/src/components/WebPub/StatefulReader.tsx
+++ b/src/components/WebPub/StatefulReader.tsx
@@ -49,7 +49,6 @@ import { useTimeline } from "@/core/Hooks/useTimeline";
 import { usePositionStorage } from "@/hooks/usePositionStorage";
 import { useDocumentTitle } from "@/core/Hooks/useDocumentTitle";
 import { useSpacingPresets } from "../Settings/Spacing/hooks/useSpacingPresets";
-import { useLineHeight } from "../Settings/Spacing/hooks/useLineHeight";
 import { useFonts } from "@/core/Hooks/fonts/useFonts";
 
 import { toggleActionOpen } from "@/lib/actionsReducer";
@@ -185,8 +184,6 @@ const StatefulReaderInner = ({ publication, localDataKey, positionStorage, conta
     }
   });
 
-  const lineHeightOptions = useLineHeight();
-
   const documentTitleFormat = preferences.metadata?.documentTitle?.format;
 
   let documentTitle: string | undefined;
@@ -318,7 +315,6 @@ const StatefulReaderInner = ({ publication, localDataKey, positionStorage, conta
     injectFontResources,
     removeFontResources,
     getFontInjectables,
-    lineHeightOptions,
     contentProtectionConfig: resolveContentProtectionConfig(preferences.contentProtection, t),
     onNavigatorReady: () => {
       dispatch(setLoading(false));

--- a/src/preferences/hooks/useFilteredPreferenceKeys.ts
+++ b/src/preferences/hooks/useFilteredPreferenceKeys.ts
@@ -10,30 +10,51 @@ import {
   ThSpacingSettingsKeys
 } from "@/preferences/models";
 import { usePreferenceKeys } from "./usePreferenceKeys";
+import ReadiumCSSSettings from "@readium/css/css/vars/settings.json";
 
-const EXCLUDED_CJK = [
-  ThTextSettingsKeys.textAlign,
-  ThTextSettingsKeys.hyphens,
-  ThTextSettingsKeys.ligatures,
-  ThSpacingSettingsKeys.paragraphIndent,
-  ThSpacingSettingsKeys.wordSpacing,
-  ThTextSettingsKeys.textNormalize,
-];
+// Translates ReadiumCSS property names to ThSettingsKeys.
+// colCount is intentionally omitted — it's handled separately with the !isFXL guard below.
+const READIUM_CSS_TO_SETTINGS_KEY: Record<string, string | undefined> = {
+  bodyHyphens: ThTextSettingsKeys.hyphens,
+  a11yNormalize: ThTextSettingsKeys.textNormalize,
+  letterSpacing: ThSpacingSettingsKeys.letterSpacing,
+  textAlign: ThTextSettingsKeys.textAlign,
+  paraIndent: ThSpacingSettingsKeys.paragraphIndent,
+  wordSpacing: ThSpacingSettingsKeys.wordSpacing,
+  ligatures: ThTextSettingsKeys.ligatures,
+  noRuby: ThTextSettingsKeys.noRuby
+};
 
-// Keys that are not applicable for each script mode and should be hidden from settings UI
+// Keys appearing in any mode's `added` are mode-specific — they should be excluded
+// from every mode that does not explicitly list them in `added`.
+const globallyAdded = new Set(
+  Object.values(ReadiumCSSSettings).flatMap(entry => entry.added)
+);
+
+const deriveExcluded = (entry: { disabled: string[]; added: string[] }): string[] => {
+  const fromDisabled = entry.disabled
+    .map(k => READIUM_CSS_TO_SETTINGS_KEY[k])
+    .filter((k): k is string => k !== undefined);
+
+  const fromAddedInversion = [...globallyAdded]
+    .filter(k => !entry.added.includes(k))
+    .map(k => READIUM_CSS_TO_SETTINGS_KEY[k])
+    .filter((k): k is string => k !== undefined);
+
+  return [...fromDisabled, ...fromAddedInversion];
+};
+
+// ThSettingsKeys.layout is excluded for vertical modes but is not tracked in the JSON.
+const CJK_VERTICAL_EXCLUDED = [...deriveExcluded(ReadiumCSSSettings["cjk-vertical"]), ThSettingsKeys.layout];
+
+// Keys that are not applicable for each script mode and should be hidden from settings UI.
+// Derived from @readium/css settings.json; mongolian-vertical follows cjk-vertical.
 const EXCLUDED_BY_SCRIPT_MODE: Record<ScriptMode, string[]> = {
-  "ltr": [
-    ThTextSettingsKeys.noRuby,
-  ],
-  "rtl": [
-    ThTextSettingsKeys.hyphens,
-    ThSpacingSettingsKeys.letterSpacing,
-    ThTextSettingsKeys.textNormalize,
-    ThTextSettingsKeys.noRuby,
-  ],
-  "cjk-horizontal": EXCLUDED_CJK,
-  "cjk-vertical": [...EXCLUDED_CJK, ThSettingsKeys.layout],
-  "mongolian-vertical": [...EXCLUDED_CJK, ThSettingsKeys.layout],
+  "ltr":              deriveExcluded(ReadiumCSSSettings["default"]),
+  "rtl":              deriveExcluded(ReadiumCSSSettings["rtl"]),
+  "cjk-horizontal":   deriveExcluded(ReadiumCSSSettings["cjk-horizontal"]),
+  "cjk-vertical":       CJK_VERTICAL_EXCLUDED,
+  "mongolian-vertical": CJK_VERTICAL_EXCLUDED,
 };
 
 /**

--- a/src/preferences/hooks/useFilteredPreferenceKeys.ts
+++ b/src/preferences/hooks/useFilteredPreferenceKeys.ts
@@ -2,7 +2,7 @@
 
 import { useMemo } from "react";
 
-import { ScriptMode } from "@readium/navigator";
+import { ScriptMode, RCSSSettingsEntry } from "@readium/navigator";
 import { useAppSelector } from "@/lib/hooks";
 import {
   ThSettingsKeys,
@@ -31,7 +31,7 @@ const globallyAdded = new Set(
   Object.values(ReadiumCSSSettings).flatMap(entry => entry.added)
 );
 
-const deriveExcluded = (entry: { disabled: string[]; added: string[] }): string[] => {
+const deriveExcluded = (entry: RCSSSettingsEntry): string[] => {
   const fromDisabled = entry.disabled
     .map(k => READIUM_CSS_TO_SETTINGS_KEY[k])
     .filter((k): k is string => k !== undefined);

--- a/src/preferences/models/fonts.ts
+++ b/src/preferences/models/fonts.ts
@@ -98,7 +98,7 @@ export const readiumCSSFontCollection: FontCollection = {
     label: "reader.preferences.fontFamily.oldStyle.descriptive",
     source: { type: "system" },
     spec: {
-      family: fontStacks.RS__oldStyleTf,
+      family: fontStacks.oldStyleTf,
       weights: { type: "static", values: [400, 700] },
       fallbacks: []
     }
@@ -109,7 +109,7 @@ export const readiumCSSFontCollection: FontCollection = {
     label: "reader.preferences.fontFamily.modern.descriptive",
     source: { type: "system" },
     spec: {
-      family: fontStacks.RS__modernTf,
+      family: fontStacks.modernTf,
       weights: { type: "static", values: [400, 700] },
       fallbacks: []
     }
@@ -120,7 +120,7 @@ export const readiumCSSFontCollection: FontCollection = {
     label: "reader.preferences.fontFamily.sans",
     source: { type: "system" },
     spec: {
-      family: fontStacks.RS__sansTf,
+      family: fontStacks.sansTf,
       weights: { type: "static", values: [400, 700] },
       fallbacks: []
     }
@@ -131,7 +131,7 @@ export const readiumCSSFontCollection: FontCollection = {
     label: "reader.preferences.fontFamily.humanist.descriptive",
     source: { type: "system" },
     spec: {
-      family: fontStacks.RS__humanistTf,
+      family: fontStacks.humanistTf,
       weights: { type: "static", values: [400, 700] },
       fallbacks: []
     }
@@ -142,7 +142,7 @@ export const readiumCSSFontCollection: FontCollection = {
     label: "reader.preferences.fontFamily.monospace",
     source: { type: "system" },
     spec: {
-      family: fontStacks.RS__monospaceTf,
+      family: fontStacks.monospaceTf,
       weights: { type: "static", values: [400, 700] },
       fallbacks: []
     }
@@ -297,8 +297,8 @@ export const chineseTraditionalCollection: FontCollection = {
 };
 
 export const japaneseCollection: FontCollection = {
-  "japanese-sans": sysFontDef("japanese-sans", "Sans-Serif", '"Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif'),
-  "japanese-serif": sysFontDef("japanese-serif", "Serif", '"Hiragino Mincho ProN", "Yu Mincho", "MS PMincho", serif'),
+  "japanese-sans": sysFontDef("japanese-sans", "Sans-Serif", fontStacks["sans-serif-ja"]),
+  "japanese-serif": sysFontDef("japanese-serif", "Serif", fontStacks["serif-ja"]),
   ...createDefinitionsFromGoogleFonts({
     cssUrl: "https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Noto+Serif+JP:wght@200..900",
     options: {
@@ -314,8 +314,8 @@ export const japaneseCollection: FontCollection = {
 };
 
 export const japaneseVerticalCollection: FontCollection = {
-  "japanese-v-serif": sysFontDef("japanese-v-serif", "Serif", '"Hiragino Mincho ProN", "Yu Mincho", "MS PMincho", serif'),
-  "japanese-v-sans": sysFontDef("japanese-v-sans", "Sans-Serif", '"Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", sans-serif'),
+  "japanese-v-sans": sysFontDef("japanese-v-sans", "Sans-Serif", fontStacks["sans-serif-ja-v"]),
+  "japanese-v-serif": sysFontDef("japanese-v-serif", "Serif", fontStacks["serif-ja-v"]),
   ...createDefinitionsFromGoogleFonts({
     cssUrl: "https://fonts.googleapis.com/css2?family=Noto+Serif+JP:wght@200..900&family=Shippori+Mincho:wght@400..800&family=Noto+Sans+JP:wght@100..900",
     options: {

--- a/src/preferences/models/theme.ts
+++ b/src/preferences/models/theme.ts
@@ -11,14 +11,14 @@ export enum ThThemeKeys {
 }
 
 export const lightTheme = {
-  background: ReadiumCSSColors.RS__backgroundColor, // Color of background
-  text: ReadiumCSSColors.RS__textColor,    // Color of text
+  background: ReadiumCSSColors.backgroundColor, // Color of background
+  text: ReadiumCSSColors.textColor,    // Color of text
   link: "#0000ee",                // Color of links
   visited: "#551a8b",             // Color of visited links
   subdue: "#808080",              // Color of subdued elements
   disable: "#808080",             // color for :disabled
   hover: "#d9d9d9",               // color of background for :hover
-  onHover: ReadiumCSSColors.RS__textColor, // color of text for :hover
+  onHover: ReadiumCSSColors.textColor, // color of text for :hover
   select: "#b4d8fe",              // color of selected background
   onSelect: "inherit",            // color of selected text
   focus: "#0067f4",               // color of :focus-visible


### PR DESCRIPTION
This implements i18n-data from Readium CSS (https://github.com/readium/css/pull/230)

Primarily, this leverages the `lineHeightCompensation` for the language in order to adjust the line-height presets to the publication’s language/script. 

E.g. for Japanese, if `ThLineHeight.loose` is `1.75` it will be `2` – and `1.75` will be the value for `normal`, which is to be expected as line-height is generally 10–20% more in Japanese – otherwise our `loose` value would be what is expected as `normal`.  