### PR TITLE
Fix peripherals

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "bugs": {
     "url": "https://github.com/edrlab/thorium-web/issues"
   },
-  "version": "1.5.1",
+  "version": "1.5.2",
   "private": false,
   "files": [
     "./dist"
@@ -86,9 +86,9 @@
   "dependencies": {
     "@edrlab/thorium-locales": "github:edrlab/thorium-locales",
     "@readium/css": ">=2.0.5",
-    "@readium/navigator": ">=2.5.5",
-    "@readium/navigator-html-injectables": "^2.4.2",
-    "@readium/shared": "^2.2.0",
+    "@readium/navigator": "^2.5.6",
+    "@readium/navigator-html-injectables": "^2.4.3",
+    "@readium/shared": "^2.2.1",
     "@reduxjs/toolkit": "^2.11.2",
     "classnames": "^2.5.1",
     "colorthief": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
   "dependencies": {
     "@edrlab/thorium-locales": "github:edrlab/thorium-locales",
     "@readium/css": ">=2.0.5",
-    "@readium/navigator": "^2.5.6",
+    "@readium/navigator": "^2.5.7",
     "@readium/navigator-html-injectables": "^2.4.3",
     "@readium/shared": "^2.2.1",
     "@reduxjs/toolkit": "^2.11.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: '>=2.0.5'
         version: 2.0.5
       '@readium/navigator':
-        specifier: '>=2.5.5'
-        version: 2.5.5
+        specifier: ^2.5.6
+        version: 2.5.6
       '@readium/navigator-html-injectables':
-        specifier: ^2.4.2
-        version: 2.4.2
+        specifier: ^2.4.3
+        version: 2.4.3
       '@readium/shared':
-        specifier: ^2.2.0
-        version: 2.2.0
+        specifier: ^2.2.1
+        version: 2.2.1
       '@reduxjs/toolkit':
         specifier: ^2.11.2
         version: 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
@@ -1771,16 +1771,16 @@ packages:
   '@readium/css@2.0.5':
     resolution: {integrity: sha512-rQWeDFSS9UfRTFFdWIhlko0jtkL9dOfNTqFjgMumlguromsyHC9/lGmbWDde7deEeE5ns+yBOSGKixMU0wqZ4A==}
 
-  '@readium/navigator-html-injectables@2.4.2':
-    resolution: {integrity: sha512-C08vjzYek19VU9JnCvhTorO8xVsR8hcCzSCD0IondBYOtcRbBzu18Ezp3WQR47/a/9tQMGicOS9knmmll1fZuw==}
+  '@readium/navigator-html-injectables@2.4.3':
+    resolution: {integrity: sha512-+hFlfsgSU6FcoK5fKt+TJqDUFgEsOBIal7B8YRGlK5YvT2JfMoU07rkwgDKah4Dx1Y6L1tgFUEsiOqB7nibNaw==}
     engines: {node: '>=18'}
 
-  '@readium/navigator@2.5.5':
-    resolution: {integrity: sha512-sMFq+zk/UPJhe+LCF3EwHGaFHR2xJZnvGHDw6u1L/UhZ6HsT4CppgqzGhdrQaZFdxEjqvE4Aa4u9EpS3tT/Few==}
+  '@readium/navigator@2.5.6':
+    resolution: {integrity: sha512-uom8HO8+0U+yHTgIbXa0ID/KZwHZetAm9pPNgoNpVzv32U1VZattxmddT6iBwXjtC7R1AexkFtRDFc0EXN1QIg==}
     engines: {node: '>=18'}
 
-  '@readium/shared@2.2.0':
-    resolution: {integrity: sha512-nfrMlF0/rgFvv3FNOsUehKDKHRHv6FKvakpnIs4aeDZS5TujCNlwWbuSCogSTQwJe+GMplWR5/T9B+bb6SZetA==}
+  '@readium/shared@2.2.1':
+    resolution: {integrity: sha512-FSEYdxKAVB/gaGVvIiLh/6Fa7/FEVbETjbKJggIqOeOtR4xGl6SuMY7HH86DdMgVacXFRYzWvEuIkqFCNRFMRQ==}
     engines: {node: '>=18'}
 
   '@reduxjs/toolkit@2.11.2':
@@ -3847,6 +3847,10 @@ packages:
 
   thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/9210d2dd6f0941833bf9de39659029a5e060e9c3:
     resolution: {gitHosted: true, integrity: sha512-11WJ645om4/nCe8/WU7FlTGGjD2C2KYQITXHGKpZKjSUKNohhHkTXb5a2aKVDyplbj/aLCDwrMVImZXDE5xcrw==, tarball: https://codeload.github.com/edrlab/thorium-locales/tar.gz/9210d2dd6f0941833bf9de39659029a5e060e9c3}
+    version: 1.0.0
+
+  thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/b416fdb5cfa7ade7562fe108550e3b566857a7b1:
+    resolution: {gitHosted: true, integrity: sha512-MyAf81YZDoD5Dq1nr1ZVG7XFrvHniHqWbp37Gjg+sXCaNV4GmCP50IBbjA0ulr0iVdFylHHkDihMolsMqETotQ==, tarball: https://codeload.github.com/edrlab/thorium-locales/tar.gz/b416fdb5cfa7ade7562fe108550e3b566857a7b1}
     version: 1.0.0
 
   tinyexec@0.3.2:
@@ -6193,13 +6197,13 @@ snapshots:
 
   '@readium/css@2.0.5': {}
 
-  '@readium/navigator-html-injectables@2.4.2': {}
+  '@readium/navigator-html-injectables@2.4.3': {}
 
-  '@readium/navigator@2.5.5': {}
+  '@readium/navigator@2.5.6': {}
 
-  '@readium/shared@2.2.0':
+  '@readium/shared@2.2.1':
     dependencies:
-      '@edrlab/thorium-locales': thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/9210d2dd6f0941833bf9de39659029a5e060e9c3
+      '@edrlab/thorium-locales': thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/b416fdb5cfa7ade7562fe108550e3b566857a7b1
 
   '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)':
     dependencies:
@@ -8557,6 +8561,8 @@ snapshots:
       any-promise: 1.3.0
 
   thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/9210d2dd6f0941833bf9de39659029a5e060e9c3: {}
+
+  thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/b416fdb5cfa7ade7562fe108550e3b566857a7b1: {}
 
   tinyexec@0.3.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: '>=2.0.5'
         version: 2.0.5
       '@readium/navigator':
-        specifier: ^2.5.6
-        version: 2.5.6
+        specifier: ^2.5.7
+        version: 2.5.7
       '@readium/navigator-html-injectables':
         specifier: ^2.4.3
         version: 2.4.3
@@ -1775,8 +1775,8 @@ packages:
     resolution: {integrity: sha512-+hFlfsgSU6FcoK5fKt+TJqDUFgEsOBIal7B8YRGlK5YvT2JfMoU07rkwgDKah4Dx1Y6L1tgFUEsiOqB7nibNaw==}
     engines: {node: '>=18'}
 
-  '@readium/navigator@2.5.6':
-    resolution: {integrity: sha512-uom8HO8+0U+yHTgIbXa0ID/KZwHZetAm9pPNgoNpVzv32U1VZattxmddT6iBwXjtC7R1AexkFtRDFc0EXN1QIg==}
+  '@readium/navigator@2.5.7':
+    resolution: {integrity: sha512-OhRBocou6jFHLAPjUQB42yECp18zhu8P9R4dsnPMdCnbF1Rtm3Kzn9nuRvPCtN0vnbP4ToRnEYrhbc2YBRA7MQ==}
     engines: {node: '>=18'}
 
   '@readium/shared@2.2.1':
@@ -6199,7 +6199,7 @@ snapshots:
 
   '@readium/navigator-html-injectables@2.4.3': {}
 
-  '@readium/navigator@2.5.6': {}
+  '@readium/navigator@2.5.7': {}
 
   '@readium/shared@2.2.1':
     dependencies:

--- a/src/components/Plugins/helpers/createAudioDefaultPlugin.ts
+++ b/src/components/Plugins/helpers/createAudioDefaultPlugin.ts
@@ -29,7 +29,7 @@ export const createAudioDefaultPlugin = (): ThPlugin => {
     id: "audio-core",
     name: "Audio Core Components",
     description: "Default components for Thorium Web Audio StatefulReader",
-    version: "1.5.1",
+    version: "1.5.2",
     components: {
       actions: {
         [ThActionsKeys.settings]: {

--- a/src/components/Plugins/helpers/createDefaultPlugin.ts
+++ b/src/components/Plugins/helpers/createDefaultPlugin.ts
@@ -35,7 +35,7 @@ export const createDefaultPlugin = (): ThPlugin => {
     id: "core",
     name: "Core Components",
     description: "Default components for Thorium Web Epub StatefulReader",
-    version: "1.5.1",
+    version: "1.5.2",
     components: {
       actions: {
         [ThActionsKeys.fullscreen]: {


### PR DESCRIPTION
- This fixes a bug where keyboard peripheral input would be hijacked by a previously focused `iframe` after navigation (see https://github.com/readium/ts-toolkit/issues/221)
- It also adds a navigation lock so that FramePool Managers do not become overwhelmed with quick-fire navigation (see see https://github.com/readium/ts-toolkit/issues/190)