### PR TITLE
Audio player fixes

### DIFF
--- a/docs/packages/Core/API/Store.md
+++ b/docs/packages/Core/API/Store.md
@@ -143,6 +143,8 @@ interface PublicationReducerState {
   atPublicationStart: boolean;
   atPublicationEnd: boolean;
   unstableTimeline?: UnstableTimeline;
+  adjacentTimelineItems: { previous: AdjacentTimelineItem | null; next: AdjacentTimelineItem | null };
+  coverTheme?: ThemeTokens;
 }
 ```
 
@@ -158,6 +160,8 @@ interface PublicationReducerState {
 - `setTimeline`: Set timeline data
 - `setTocTree`: Set table of contents tree
 - `setTocEntry`: Set current TOC entry
+- `setAdjacentTimelineItems`: Set adjacent timeline items (previous/next)
+- `setCoverTheme`: Set the cover-extracted theme tokens (runtime only, not persisted)
 
 > [!IMPORTANT]
 > `isRTL` reflects the **publication content direction** (set from the manifest). For UI direction (driven by the user's locale preference), use `useLocale().direction` from `react-aria` instead.
@@ -260,6 +264,7 @@ interface ThemeReducerState {
   prefersContrast: ThContrast;
   forcedColors: boolean;
   breakpoint?: ThBreakpoints;
+  containerBreakpoint?: ThBreakpoints;
 }
 ```
 
@@ -272,6 +277,7 @@ interface ThemeReducerState {
 - `setContrast`: Set contrast preference
 - `setForcedColors`: Set forced colors mode
 - `setBreakpoint`: Set current breakpoint
+- `setContainerBreakpoint`: Set current container breakpoint
 
 ### Preferences Reducer
 

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
   },
   "peerDependencies": {
     "@readium/css": ">=2.0.5",
-    "@readium/navigator": ">=2.5.8",
+    "@readium/navigator": ">=2.6.1",
     "@readium/navigator-html-injectables": ">=2.4.4",
-    "@readium/shared": "^2.2.0",
+    "@readium/shared": ">=2.2.3",
     "@reduxjs/toolkit": "^2.11.2",
     "i18next": "^25.8.13",
     "i18next-browser-languagedetector": "^8.2.1",
@@ -86,9 +86,9 @@
   "dependencies": {
     "@edrlab/thorium-locales": "github:edrlab/thorium-locales",
     "@readium/css": ">=2.0.5",
-    "@readium/navigator": ">=2.5.8",
+    "@readium/navigator": ">=2.6.1",
     "@readium/navigator-html-injectables": ">=2.4.4",
-    "@readium/shared": "^2.2.1",
+    "@readium/shared": ">=2.2.3",
     "@reduxjs/toolkit": "^2.11.2",
     "classnames": "^2.5.1",
     "colorthief": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,14 +15,14 @@ importers:
         specifier: '>=2.0.5'
         version: 2.0.5
       '@readium/navigator':
-        specifier: '>=2.5.8'
-        version: 2.5.8
+        specifier: '>=2.6.1'
+        version: 2.6.1
       '@readium/navigator-html-injectables':
         specifier: '>=2.4.4'
         version: 2.4.4
       '@readium/shared':
-        specifier: ^2.2.1
-        version: 2.2.1
+        specifier: '>=2.2.3'
+        version: 2.2.3
       '@reduxjs/toolkit':
         specifier: ^2.11.2
         version: 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.4)(redux@5.0.1))(react@19.2.4)
@@ -1176,12 +1176,12 @@ packages:
     resolution: {integrity: sha512-Ow6xaV9FNq2Ech8MSGgb0c1D+ozSgrHu3hYhuL8BxVL4CxCgaEPWzXEDyuc3jM+Ep60bK3I+MJkhUirdlFwZaQ==}
     engines: {node: '>=18'}
 
-  '@readium/navigator@2.5.8':
-    resolution: {integrity: sha512-j8Ak8TRB+V2e4E9h+hVF1d3sY1ax1LsrH2Uu1ppwL56uE/fmtxdSm6S7VxnYOBdCe7pincIQ7HUwa/PBDxue5A==}
+  '@readium/navigator@2.6.1':
+    resolution: {integrity: sha512-xbIvlbXrhHcxK73ctztp0G7YrkzSDEK0LwKNfBlaHoXQ9XGNNVt2ZPcm80QmQJdkDfPyC1C8DK9y/J2YM5rB7g==}
     engines: {node: '>=18'}
 
-  '@readium/shared@2.2.1':
-    resolution: {integrity: sha512-FSEYdxKAVB/gaGVvIiLh/6Fa7/FEVbETjbKJggIqOeOtR4xGl6SuMY7HH86DdMgVacXFRYzWvEuIkqFCNRFMRQ==}
+  '@readium/shared@2.2.3':
+    resolution: {integrity: sha512-DW6BE0J3oBdb87q9gEz1UpGBgzJkuDyDnboChuGwpaXYNfOuy57PsDl52ch426v7CzoR4hNi8VoUXL1YHn4MPA==}
     engines: {node: '>=18'}
 
   '@reduxjs/toolkit@2.11.2':
@@ -4525,9 +4525,9 @@ snapshots:
 
   '@readium/navigator-html-injectables@2.4.4': {}
 
-  '@readium/navigator@2.5.8': {}
+  '@readium/navigator@2.6.1': {}
 
-  '@readium/shared@2.2.1':
+  '@readium/shared@2.2.3':
     dependencies:
       '@edrlab/thorium-locales': thorium-locales@https://codeload.github.com/edrlab/thorium-locales/tar.gz/b416fdb5cfa7ade7562fe108550e3b566857a7b1
 

--- a/src/components/Audio/assets/styles/thorium-web.audioCover.module.css
+++ b/src/components/Audio/assets/styles/thorium-web.audioCover.module.css
@@ -20,6 +20,7 @@
 }
 
 .audioCoverPlaceholder {
+  height: 100%;
   max-height: var(--th-layout-constraints-cover, 300px);
   width: auto;
   max-width: 100%;

--- a/src/components/Reader/StatefulReaderWrapper.tsx
+++ b/src/components/Reader/StatefulReaderWrapper.tsx
@@ -20,9 +20,8 @@ import {
   setMonochrome,
   setReducedMotion,
   setReducedTransparency,
-  setCoverTheme
 } from "@/lib/themeReducer";
-import { setFontLanguage } from "@/lib/publicationReducer";
+import { setFontLanguage, setCoverTheme } from "@/lib/publicationReducer";
 import { propsToCSSVars } from "@/core/Helpers/propsToCSSVars";
 import { prefixString } from "@/core/Helpers/prefixString";
 import { useCoverBlobUrl } from "@/hooks/useCoverBlobUrl";

--- a/src/components/Settings/StatefulTheme.tsx
+++ b/src/components/Settings/StatefulTheme.tsx
@@ -47,7 +47,7 @@ export const StatefulTheme = () => {
   const themeObject = useAppSelector(state => state.theming.theme);
   const theme = profile === "audio" ? (themeObject.audio ?? "auto") : (isFXL ? (themeObject.fxl ?? "auto") : (themeObject.reflow ?? "auto"));
   const colorScheme = useAppSelector(state => state.theming.colorScheme);
-  const coverTheme = useAppSelector(state => state.theming.coverTheme);
+  const coverTheme = useAppSelector(state => state.publication.coverTheme);
 
   const themeItems = useRef<(ThemeKeyType | "auto")[]>(
     themeArray.filter((theme: ThemeKeyType | "auto") => {

--- a/src/config/publications.ts
+++ b/src/config/publications.ts
@@ -17,6 +17,8 @@ export const PUBLICATION_MANIFESTS = {
   "molly-hopper": "https://publication-server.readium.org/webpub/Z3M6Ly9yZWFkaXVtLXBsYXlncm91bmQtZmlsZXMvZGVtby9tb2xseS1ob3BwZXItdjEuMS53ZWJwdWI/manifest.json",
   // Audiobooks
   "flatland": "https://readium.org/webpub-manifest/examples/Flatland/manifest.json",
+  "art-of-letters": "https://publication-server.readium.org/webpub/Z3M6Ly9yZWFkaXVtLXBsYXlncm91bmQtZmlsZXMvZGVtby9hcnRfbGV0dGVycy56YWI%2Fmanifest.json",
+  "around-the-world": "https://publication-server.readium.org/webpub/Z3M6Ly9yZWFkaXVtLXBsYXlncm91bmQtZmlsZXMvZGVtby9Bcm91bmRUaGVXb3JsZEluRWlnaHR5RGF5cy5tNGI%2Fmanifest.json",
   // RTL + CJK
   "haruko": "https://publication-server.readium.org/webpub/aHR0cHM6Ly9naXRodWIuY29tL0lEUEYvZXB1YjMtc2FtcGxlcy9yZWxlYXNlcy9kb3dubG9hZC8yMDIzMDcwNC9oYXJ1a28taHRtbC1qcGVnLmVwdWI/manifest.json",
   "israel-sailing": "https://publication-server.readium.org/webpub/aHR0cHM6Ly9naXRodWIuY29tL0lEUEYvZXB1YjMtc2FtcGxlcy9yZWxlYXNlcy9kb3dubG9hZC8yMDIzMDcwNC9pc3JhZWxzYWlsaW5nLmVwdWI/manifest.json",

--- a/src/lib/publicationReducer.ts
+++ b/src/lib/publicationReducer.ts
@@ -1,6 +1,7 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 import { Locator } from "@readium/shared";
+import { ThemeTokens } from "@/preferences/hooks/useTheming";
 import { ScriptMode } from "@readium/navigator";
 import { UnstableTimeline } from "@/core/Hooks/useTimeline";
 import { TocItem, toEntryRef } from "@/helpers/buildTocTree";
@@ -24,6 +25,7 @@ export interface PublicationReducerState {
     previous: AdjacentTimelineItem | null;
     next: AdjacentTimelineItem | null;
   };
+  coverTheme?: ThemeTokens;
 }
 
 const initialState: PublicationReducerState = {
@@ -36,7 +38,8 @@ const initialState: PublicationReducerState = {
   atPublicationStart: false,
   atPublicationEnd: false,
   unstableTimeline: undefined,
-  adjacentTimelineItems: { previous: null, next: null }
+  adjacentTimelineItems: { previous: null, next: null },
+  coverTheme: undefined,
 }
 
 export const publicationSlice = createSlice({
@@ -87,6 +90,9 @@ export const publicationSlice = createSlice({
     setAdjacentTimelineItems: (state, action: { payload: { previous: AdjacentTimelineItem | null; next: AdjacentTimelineItem | null } }) => {
       state.adjacentTimelineItems = action.payload;
     },
+    setCoverTheme: (state, action: { payload: ThemeTokens | undefined }) => {
+      state.coverTheme = action.payload;
+    },
     setTocEntry: (state, action: { payload: TocItem | null }) => {
       const entry = action.payload ? toEntryRef(action.payload) : null;
       if (!state.unstableTimeline) {
@@ -116,6 +122,7 @@ export const {
   setTocTree,
   setTocEntry,
   setAdjacentTimelineItems,
+  setCoverTheme,
 } = publicationSlice.actions;
 
 export default publicationSlice.reducer;

--- a/src/lib/themeReducer.ts
+++ b/src/lib/themeReducer.ts
@@ -3,7 +3,6 @@ import { createSlice } from "@reduxjs/toolkit";
 import { ThColorScheme } from "@/core/Hooks/useColorScheme";
 import { ThContrast } from "@/core/Hooks/useContrast";
 import { ThBreakpoints } from "@/preferences/models";
-import { ThemeTokens } from "@/preferences/hooks/useTheming";
 
 export interface ThemeStateObject {
   reflow?: string;
@@ -23,7 +22,6 @@ export interface ThemeReducerState {
   monochrome: boolean;
   colorScheme: ThColorScheme;
   theme: ThemeStateObject;
-  coverTheme?: ThemeTokens;
   prefersReducedMotion: boolean;
   prefersReducedTransparency: boolean;
   prefersContrast: ThContrast;
@@ -40,7 +38,6 @@ const initialState: ThemeReducerState = {
     fxl: "auto",
     audio: "auto"
   },
-  coverTheme: undefined,
   prefersReducedMotion: false,
   prefersReducedTransparency: false, 
   prefersContrast: ThContrast.none,
@@ -61,9 +58,6 @@ export const themeSlice = createSlice({
     },
     setTheme: (state, action: ThemeStateChangePayload) => {
       state.theme[action.payload.key] = action.payload.value || "auto"
-    },
-    setCoverTheme: (state, action) => {
-      state.coverTheme = action.payload
     },
     setReducedMotion: (state, action) => {
       state.prefersReducedMotion = action.payload
@@ -87,11 +81,10 @@ export const themeSlice = createSlice({
 })
 
 // Action creators are generated for each case reducer function
-export const { 
-  setMonochrome, 
-  setColorScheme, 
-  setTheme, 
-  setCoverTheme,
+export const {
+  setMonochrome,
+  setColorScheme,
+  setTheme,
   setReducedMotion, 
   setReducedTransparency, 
   setContrast, 

--- a/src/preferences/hooks/useTheming.ts
+++ b/src/preferences/hooks/useTheming.ts
@@ -128,12 +128,12 @@ export const useTheming = <T extends string>({
   const inferThemeAuto = useCallback(() => {
     if (autoThemeSource === "cover") {
       if (coverThemeTokens) return "cover" as T;
-      // Pending: hold until resolved; failed: fall back to system
-      if (!coverThemeFailed) return undefined;
+      // Only hold while actively fetching; no URL or fetch failed → fall through to system
+      if (!coverThemeFailed && coverUrl) return undefined;
     }
     // Default behavior: use colorScheme (system)
     return colorSchemeRef.current === ThColorScheme.dark ? systemKeys?.dark : systemKeys?.light;
-  }, [systemKeys, autoThemeSource, coverThemeTokens, coverThemeFailed]);
+  }, [systemKeys, autoThemeSource, coverThemeTokens, coverThemeFailed, coverUrl]);
 
   const setThemeCustomProps = useCallback((t?: string) => {
     if (!t) {


### PR DESCRIPTION
This fixes audio player bugs that surfaced as we added publications to test. Specifically:

- `useTheming` hook would struggle to handle an audiobook without a cover, resulting in an incomplete `auto` theme. It now falls back to `colorScheme` in that specific case;
- the fallback cover for such publications was not sized correctly;
- Publication’s Timeline API would struggle with media fragments containing decimals, due to `LocatorLocations.time()` using `parseInt` instead of `parseFloat`, resulting in Previous/Next playback controls not working as expected. 